### PR TITLE
Call cdc_disconnect after disabling IRQs

### DIFF
--- a/cdcacm.c
+++ b/cdcacm.c
@@ -298,10 +298,10 @@ cinit(void *config)
 void
 cfini()
 {
-	cdc_disconnect();
 #if defined(STM32F4)
 	nvic_disable_irq(NVIC_OTG_FS_IRQ);
 #endif
+	cdc_disconnect();
 }
 
 int


### PR DESCRIPTION
cdc_disconnect sets the usbd_dev pointer to null. When nvic_disable_irq is called with NVIC_OTG_FS_IRQ the signal handler invokes [otg_fs_isr](https://github.com/PX4/Bootloader/blob/a8c0160397062d1760f35ef8eda84ef0db709e63/cdcacm.c#L286) which passes the null pointer and traps us in the blocking_handler. 

This manifest on our hardware via a software triggered reset into the bootloader for remote update. If the update failed or times out and the bootloader tries to jump back to the app the system will hang after calling cfini. Disabling USB interrupts before invalidating the usbd device pointer fixes the issue. 