### PR TITLE
USART and USB Bootloader ability added.

### DIFF
--- a/bl.c
+++ b/bl.c
@@ -426,9 +426,6 @@ crc32(const uint8_t *src, unsigned len, unsigned state)
 	return state;
 }
 
-/*
- * Bootloader returns -1 for timeout and 0 if it received the reboot command from the uploader (successful).
- */
 void
 bootloader(unsigned timeout)
 {

--- a/bl.c
+++ b/bl.c
@@ -374,6 +374,18 @@ cin_wait(unsigned timeout)
 	return c;
 }
 
+/**
+ * Function to wait for EOC
+ * 
+ * @param timeout length of time in ms to wait for the EOC to be received
+ * @return true if the EOC is returned within the timeout perio, else false
+ */
+inline static bool
+wait_for_eoc(unsigned timeout)
+{
+	return cin_wait(timeout) == PROTO_EOC;
+}
+
 static void
 cout_word(uint32_t val)
 {
@@ -478,7 +490,7 @@ bootloader(unsigned timeout)
 			//
 		case PROTO_GET_SYNC:
 			/* expect EOC */
-			if (cin_wait(1000) != PROTO_EOC)
+			if (!wait_for_eoc(1000))
 				goto cmd_bad;
 			break;
 
@@ -497,7 +509,7 @@ bootloader(unsigned timeout)
 			arg = cin_wait(1000);
 			if (arg < 0)
 				goto cmd_bad;
-			if (cin_wait(1000) != PROTO_EOC)
+			if (!wait_for_eoc(1000))
 				goto cmd_bad;
 
 			switch (arg) {
@@ -538,7 +550,7 @@ bootloader(unsigned timeout)
 			//
 		case PROTO_CHIP_ERASE:
 			/* expect EOC */
-			if (cin_wait(1000) != PROTO_EOC)
+			if (!wait_for_eoc(1000))
 				goto cmd_bad;
 
 			// clear the bootloader LED while erasing - it stops blinking at random
@@ -589,7 +601,7 @@ bootloader(unsigned timeout)
 					goto cmd_bad;
 				flash_buffer.c[i] = c;
 			}
-			if (cin_wait(1000) != PROTO_EOC)
+			if (!wait_for_eoc(1000))
 				goto cmd_bad;
 			if (address == 0) {
 				// save the first word and don't program it until everything else is done
@@ -617,7 +629,7 @@ bootloader(unsigned timeout)
 			//
 		case PROTO_GET_CRC:
 			// expect EOC
-			if (cin_wait(1000) != PROTO_EOC)
+			if (!wait_for_eoc(1000))
 				goto cmd_bad;
 
 			// compute CRC of the programmed area
@@ -647,7 +659,7 @@ bootloader(unsigned timeout)
 				if (cin_word(&index, 100))
 					goto cmd_bad;
 				// expect EOC
-				if (cin_wait(1000) != PROTO_EOC)
+				if (!wait_for_eoc(1000))
 					goto cmd_bad;
 				cout_word(flash_func_read_otp(index));
 			}
@@ -664,7 +676,7 @@ bootloader(unsigned timeout)
 				if (cin_word(&index, 100))
 					goto cmd_bad;
 				// expect EOC
-				if (cin_wait(1000) != PROTO_EOC)
+				if (!wait_for_eoc(1000))
 					goto cmd_bad;
 				cout_word(flash_func_read_sn(index));
 			}
@@ -677,7 +689,7 @@ bootloader(unsigned timeout)
 		case PROTO_GET_CHIP:
 			{ 
 				// expect EOC
-				if (cin_wait(1000) != PROTO_EOC)
+				if (!wait_for_eoc(1000))
 					goto cmd_bad;
 		      	cout_word(*(uint32_t *)DBGMCU_IDCODE);
 			}
@@ -699,7 +711,7 @@ bootloader(unsigned timeout)
 				if (boot_delay > BOOT_DELAY_MAX)
 					goto cmd_bad;
 				// expect EOC
-				if (cin_wait(1000) != PROTO_EOC)
+				if (!wait_for_eoc(1000))
 					goto cmd_bad;
 
 				uint32_t sig1 = flash_func_read_word(BOOT_DELAY_ADDRESS);
@@ -724,7 +736,7 @@ bootloader(unsigned timeout)
 		//
 		case PROTO_BOOT:
 			// expect EOC
-			if (cin_wait(1000) != PROTO_EOC)
+			if (!wait_for_eoc(1000))
 				goto cmd_bad;
 
 			// program the deferred first word

--- a/bl.c
+++ b/bl.c
@@ -492,7 +492,7 @@ bootloader(unsigned timeout)
 			//
 		case PROTO_GET_SYNC:
 			/* expect EOC */
-			if (!wait_for_eoc(1000))
+			if (!wait_for_eoc(2))
 				goto cmd_bad;
 			break;
 
@@ -511,7 +511,7 @@ bootloader(unsigned timeout)
 			arg = cin_wait(1000);
 			if (arg < 0)
 				goto cmd_bad;
-			if (!wait_for_eoc(1000))
+			if (!wait_for_eoc(2))
 				goto cmd_bad;
 
 			switch (arg) {
@@ -552,7 +552,7 @@ bootloader(unsigned timeout)
 			//
 		case PROTO_CHIP_ERASE:
 			/* expect EOC */
-			if (!wait_for_eoc(1000))
+			if (!wait_for_eoc(2))
 				goto cmd_bad;
 
 			// clear the bootloader LED while erasing - it stops blinking at random
@@ -586,7 +586,7 @@ bootloader(unsigned timeout)
 			//
 		case PROTO_PROG_MULTI:		// program bytes
 			// expect count
-			arg = cin_wait(1000);
+			arg = cin_wait(50);
 			if (arg < 0)
 				goto cmd_bad;
 
@@ -603,7 +603,7 @@ bootloader(unsigned timeout)
 					goto cmd_bad;
 				flash_buffer.c[i] = c;
 			}
-			if (!wait_for_eoc(1000))
+			if (!wait_for_eoc(2))
 				goto cmd_bad;
 			if (address == 0) {
 				// save the first word and don't program it until everything else is done
@@ -631,7 +631,7 @@ bootloader(unsigned timeout)
 			//
 		case PROTO_GET_CRC:
 			// expect EOC
-			if (!wait_for_eoc(1000))
+			if (!wait_for_eoc(2))
 				goto cmd_bad;
 
 			// compute CRC of the programmed area
@@ -661,7 +661,7 @@ bootloader(unsigned timeout)
 				if (cin_word(&index, 100))
 					goto cmd_bad;
 				// expect EOC
-				if (!wait_for_eoc(1000))
+				if (!wait_for_eoc(2))
 					goto cmd_bad;
 				cout_word(flash_func_read_otp(index));
 			}
@@ -678,7 +678,7 @@ bootloader(unsigned timeout)
 				if (cin_word(&index, 100))
 					goto cmd_bad;
 				// expect EOC
-				if (!wait_for_eoc(1000))
+				if (!wait_for_eoc(2))
 					goto cmd_bad;
 				cout_word(flash_func_read_sn(index));
 			}
@@ -691,7 +691,7 @@ bootloader(unsigned timeout)
 		case PROTO_GET_CHIP:
 			{ 
 				// expect EOC
-				if (!wait_for_eoc(1000))
+				if (!wait_for_eoc(2))
 					goto cmd_bad;
 		      	cout_word(*(uint32_t *)DBGMCU_IDCODE);
 			}
@@ -713,7 +713,7 @@ bootloader(unsigned timeout)
 				if (boot_delay > BOOT_DELAY_MAX)
 					goto cmd_bad;
 				// expect EOC
-				if (!wait_for_eoc(1000))
+				if (!wait_for_eoc(2))
 					goto cmd_bad;
 
 				uint32_t sig1 = flash_func_read_word(BOOT_DELAY_ADDRESS);
@@ -738,7 +738,7 @@ bootloader(unsigned timeout)
 		//
 		case PROTO_BOOT:
 			// expect EOC
-			if (!wait_for_eoc(1000))
+			if (!wait_for_eoc(2))
 				goto cmd_bad;
 
 			// program the deferred first word

--- a/bl.c
+++ b/bl.c
@@ -259,12 +259,14 @@ jump_to_app()
 	systick_interrupt_disable();
 	systick_counter_disable();
 
-	/* and set a specific LED pattern */
-	led_off(LED_ACTIVITY);
-	led_on(LED_BOOTLOADER);
-
-	/* the interface */
+	/* deinitialise the interface */
 	cfini();
+
+	/* reset the clock */
+	clock_deinit();
+
+	/* deinitialise the board */
+	board_deinit();
 
 	/* switch exception handlers to the application */
 	SCB_VTOR = APP_LOAD_ADDRESS;

--- a/bl.h
+++ b/bl.h
@@ -43,6 +43,12 @@
  * Generic bootloader functions.
  */
 
+/* enum for whether bootloading via USB or USART */
+enum{
+  USART,
+  USB
+};
+
 /* board info forwarded from board-specific code to booloader */
 struct boardinfo {
 	uint32_t	board_type;
@@ -55,7 +61,7 @@ struct boardinfo {
 extern struct boardinfo board_info;
 
 extern void jump_to_app(void);
-extern void bootloader(unsigned timeout);
+extern int bootloader(unsigned timeout, uint8_t _bl_type);
 extern void delay(unsigned msec);
 
 #define BL_WAIT_MAGIC	0x19710317		/* magic number in PWR regs to wait in bootloader */
@@ -102,7 +108,7 @@ extern uint32_t flash_func_read_sn(uint32_t address);
  * Interface in/output.
  */
 
-extern void cinit(void *config);
+extern void cinit(void *config, uint8_t interface);
 extern void cfini(void);
 extern int cin(void);
 extern void cout(uint8_t *buf, unsigned len);

--- a/bl.h
+++ b/bl.h
@@ -98,6 +98,8 @@ extern void led_off(unsigned led);
 extern void led_toggle(unsigned led);
 
 /* flash helpers from main_*.c */
+extern void board_deinit(void);
+extern void clock_deinit(void);
 extern uint32_t flash_func_sector_size(unsigned sector);
 extern void flash_func_erase_sector(unsigned sector);
 extern void flash_func_write_word(uint32_t address, uint32_t word);

--- a/bl.h
+++ b/bl.h
@@ -45,6 +45,7 @@
 
 /* enum for whether bootloading via USB or USART */
 enum{
+  NONE,
   USART,
   USB
 };
@@ -61,7 +62,7 @@ struct boardinfo {
 extern struct boardinfo board_info;
 
 extern void jump_to_app(void);
-extern int bootloader(unsigned timeout, uint8_t _bl_type);
+extern void bootloader(unsigned timeout);
 extern void delay(unsigned msec);
 
 #define BL_WAIT_MAGIC	0x19710317		/* magic number in PWR regs to wait in bootloader */

--- a/cdcacm.c
+++ b/cdcacm.c
@@ -296,6 +296,19 @@ usb_cfini(void)
             usbd_disconnect(usbd_dev, true);
             usbd_dev = NULL;
         }
+
+#if defined(STM32F4)
+	/* Reset the USB pins to being floating inputs */
+	gpio_mode_setup(GPIOA, GPIO_MODE_INPUT, GPIO_PUPD_NONE, GPIO9 | GPIO11 | GPIO12);
+
+	/* Disable the OTGFS peripheral clock */ 
+	rcc_peripheral_disable_clock(&RCC_AHB2ENR, RCC_AHB2ENR_OTGFSEN);
+
+#elif defined(STM32F1)
+	/* Reset the USB pins to being floating inputs */ 
+	gpio_set_mode(GPIOA, GPIO_MODE_INPUT,GPIO_CNF_INPUT_FLOAT, GPIO8);
+	gpio_clear(GPIOA, GPIO8);
+#endif
 }
 
 int

--- a/hw_config.h
+++ b/hw_config.h
@@ -18,6 +18,7 @@
 # define BOOTLOADER_DELAY               5000
 # define BOARD_FMU
 # define INTERFACE_USB                  1
+# define INTERFACE_USART                1
 # define USBDEVICESTRING                "PX4 BL FMU v1.x"
 # define USBPRODUCTID                   0x0010
 # define BOOT_DELAY_ADDRESS             0x000001a0
@@ -34,6 +35,17 @@
 # define BOARD_CLOCK_LEDS               RCC_AHB1ENR_IOPBEN
 # define BOARD_LED_ON                   gpio_clear
 # define BOARD_LED_OFF                  gpio_set
+
+# define BOARD_USART  					USART1
+# define BOARD_USART_CLOCK_REGISTER 	RCC_APB2ENR
+# define BOARD_USART_CLOCK_BIT      	RCC_APB2ENR_USART1EN
+
+# define BOARD_PORT_USART   			GPIOB
+# define BOARD_PORT_USART_AF 			GPIO_AF7
+# define BOARD_PIN_TX     				GPIO6
+# define BOARD_PIN_RX		     		GPIO7
+# define BOARD_USART_PIN_CLOCK_REGISTER RCC_AHB1ENR
+# define BOARD_USART_PIN_CLOCK_BIT  	RCC_AHB1ENR_IOPBEN
 
 # define BOARD_FORCE_BL_PIN             GPIO10
 # define BOARD_FORCE_BL_PORT            GPIOA
@@ -52,6 +64,7 @@
 # define BOOTLOADER_DELAY               5000
 # define BOARD_FMUV2
 # define INTERFACE_USB                  1
+# define INTERFACE_USART                1
 # define USBDEVICESTRING                "PX4 BL FMU v2.x"
 # define USBPRODUCTID                   0x0011
 # define BOOT_DELAY_ADDRESS             0x000001a0
@@ -70,6 +83,17 @@
 # define BOARD_LED_ON                   gpio_clear
 # define BOARD_LED_OFF                  gpio_set
 
+# define BOARD_USART  					USART2
+# define BOARD_USART_CLOCK_REGISTER 	RCC_APB1ENR
+# define BOARD_USART_CLOCK_BIT      	RCC_APB1ENR_USART2EN
+
+# define BOARD_PORT_USART   			GPIOD
+# define BOARD_PORT_USART_AF 			GPIO_AF7
+# define BOARD_PIN_TX     				GPIO5
+# define BOARD_PIN_RX		     		GPIO6
+# define BOARD_USART_PIN_CLOCK_REGISTER RCC_AHB1ENR
+# define BOARD_USART_PIN_CLOCK_BIT  	RCC_AHB1ENR_IOPDEN
+
 # define BOARD_FORCE_BL_PIN_OUT         GPIO14
 # define BOARD_FORCE_BL_PIN_IN          GPIO11
 # define BOARD_FORCE_BL_PORT            GPIOE
@@ -87,6 +111,7 @@
 # define BOOTLOADER_DELAY               5000
 # define BOARD_FLOW
 # define INTERFACE_USB                  1
+# define INTERFACE_USART                0
 # define USBDEVICESTRING                "PX4 BL FLOW v1.3"
 # define USBPRODUCTID                   0x0015
 
@@ -113,6 +138,7 @@
 # define BOOTLOADER_DELAY               5000
 # define BOARD_DISCOVERY
 # define INTERFACE_USB                  1
+# define INTERFACE_USART                0
 # define USBDEVICESTRING                "PX4 BL DISCOVERY"
 # define USBPRODUCTID                   0x0001
 
@@ -139,6 +165,7 @@
 # define APP_SIZE_MAX                   0xf000
 # define BOOTLOADER_DELAY               200
 # define BOARD_PIO
+# define INTERFACE_USB                	0
 # define INTERFACE_USART                1
 # define USBDEVICESTRING                ""
 # define USBPRODUCTID                   -1
@@ -183,6 +210,7 @@
 # define BOOTLOADER_DELAY               5000
 # define BOARD_AEROCORE
 # define INTERFACE_USB                  1
+# define INTERFACE_USART                0
 # define USBDEVICESTRING                "Gumstix BL AEROCORE"
 # define USBPRODUCTID                   0x1001
 
@@ -217,6 +245,7 @@
 # define BOOTLOADER_DELAY               3000
 # define BOARD_MAVSTATION
 # define INTERFACE_USB                  1
+# define INTERFACE_USART                0
 # define USBDEVICESTRING                "MAVSTATION BL v0.1"
 # define USBPRODUCTID                   0x0014
 

--- a/hw_config.h
+++ b/hw_config.h
@@ -194,6 +194,7 @@
 # define BOARD_FORCE_BL_PORT            GPIOB
 # define BOARD_FORCE_BL_CLOCK_REGISTER  RCC_APB2ENR
 # define BOARD_FORCE_BL_CLOCK_BIT       RCC_APB2ENR_IOPBEN
+# define BOARD_FORCE_BL_PULL            GPIO_CNF_INPUT_FLOAT // depend on external pull
 # define BOARD_FORCE_BL_VALUE           BOARD_FORCE_BL_PIN
 
 # define BOARD_FLASH_SECTORS            60
@@ -274,6 +275,7 @@
 # define BOARD_FORCE_BL_PORT            GPIOA
 # define BOARD_FORCE_BL_CLOCK_REGISTER  RCC_APB2ENR
 # define BOARD_FORCE_BL_CLOCK_BIT       RCC_APB2ENR_IOPAEN
+# define BOARD_FORCE_BL_PULL            GPIO_CNF_INPUT_PULL_UPDOWN // depend on external pull
 # define BOARD_FORCE_BL_VALUE           0
 
 # define BOARD_FLASH_SECTORS            116

--- a/main_f1.c
+++ b/main_f1.c
@@ -116,12 +116,8 @@ board_deinit(void)
 # error I2C GPIO config not handled yet
 #endif
 
-	/* disable the GPIO port peripheral clocks */
-	rcc_peripheral_disable_clock(&RCC_APB2ENR, RCC_APB2ENR_IOPAEN);
-	rcc_peripheral_disable_clock(&RCC_APB2ENR, RCC_APB2ENR_IOPBEN);
-	rcc_peripheral_disable_clock(&RCC_APB2ENR, RCC_APB2ENR_IOPCEN);
-	rcc_peripheral_disable_clock(&RCC_APB2ENR, RCC_APB2ENR_IOPDEN);
-	rcc_peripheral_disable_clock(&RCC_APB2ENR, RCC_APB2ENR_IOPEEN);
+	/* reset the APB2 peripheral clocks */
+	RCC_APB2ENR = 0x00000000; // XXX Magic reset number from STM32F1x reference manual
 }
 
 /**

--- a/main_f1.c
+++ b/main_f1.c
@@ -227,12 +227,12 @@ main(void)
 #endif
 
 	/* start the interface */
-	cinit(BOARD_INTERFACE_CONFIG);
+	cinit(BOARD_INTERFACE_CONFIG, USART);
 
 	while (1)
 	{
 		/* run the bootloader, possibly coming back after the timeout */
-		bootloader(timeout);
+		bootloader(timeout, USART);
 
 		/* look to see if we can boot the app */
 		jump_to_app();

--- a/main_f1.c
+++ b/main_f1.c
@@ -232,7 +232,7 @@ main(void)
 	while (1)
 	{
 		/* run the bootloader, possibly coming back after the timeout */
-		bootloader(timeout, USART);
+		bootloader(timeout);
 
 		/* look to see if we can boot the app */
 		jump_to_app();

--- a/main_f1.c
+++ b/main_f1.c
@@ -54,18 +54,12 @@ board_init(void)
 	/* if we have one, enable the force-bootloader pin */
 #ifdef BOARD_FORCE_BL_PIN
 	rcc_peripheral_enable_clock(&BOARD_FORCE_BL_CLOCK_REGISTER, BOARD_FORCE_BL_CLOCK_BIT);
-#if defined(BOARD_MAVSTATION)	
+
 	gpio_set(BOARD_FORCE_BL_PORT,BOARD_FORCE_BL_PIN);
 	gpio_set_mode(BOARD_FORCE_BL_PORT,
 		GPIO_MODE_INPUT,
-		GPIO_CNF_INPUT_PULL_UPDOWN,	/* depend on external pull */
+		BOARD_FORCE_BL_PULL,
 		BOARD_FORCE_BL_PIN);
-#else
-	gpio_set_mode(BOARD_FORCE_BL_PORT,
-		GPIO_MODE_INPUT,
-		GPIO_CNF_INPUT_FLOAT,	/* depend on external pull */
-		BOARD_FORCE_BL_PIN);
-#endif
 #endif
 
 	/* enable the backup registers */

--- a/main_f4.c
+++ b/main_f4.c
@@ -335,17 +335,8 @@ board_deinit(void)
 	/* disable the power controller clock */
 	rcc_peripheral_disable_clock(&RCC_APB1ENR, RCC_APB1ENR_PWREN);
 
-	/* disable the GPIO port peripheral clocks */
-	rcc_peripheral_disable_clock(&RCC_AHB1ENR, RCC_AHB1ENR_IOPAEN);
-	rcc_peripheral_disable_clock(&RCC_AHB1ENR, RCC_AHB1ENR_IOPBEN);
-	rcc_peripheral_disable_clock(&RCC_AHB1ENR, RCC_AHB1ENR_IOPCEN);
-	rcc_peripheral_disable_clock(&RCC_AHB1ENR, RCC_AHB1ENR_IOPDEN);
-	rcc_peripheral_disable_clock(&RCC_AHB1ENR, RCC_AHB1ENR_IOPEEN);
-	rcc_peripheral_disable_clock(&RCC_AHB1ENR, RCC_AHB1ENR_IOPEEN);
-	rcc_peripheral_disable_clock(&RCC_AHB1ENR, RCC_AHB1ENR_IOPFEN);
-	rcc_peripheral_disable_clock(&RCC_AHB1ENR, RCC_AHB1ENR_IOPGEN);
-	rcc_peripheral_disable_clock(&RCC_AHB1ENR, RCC_AHB1ENR_IOPHEN);
-	rcc_peripheral_disable_clock(&RCC_AHB1ENR, RCC_AHB1ENR_IOPIEN);
+	/* disable the AHB peripheral clocks */
+	RCC_AHB1ENR = 0x00100000; // XXX Magic reset number from STM32F4x reference manual
 }
 
 /**

--- a/main_f4.c
+++ b/main_f4.c
@@ -522,15 +522,6 @@ main(void)
 	/* configure the clock for bootloader activity */
 	clock_init();	
 	
-	/* start the interface */
-#if INTERFACE_USART
-	cinit(BOARD_INTERFACE_CONFIG_USART, USART);
-#endif
-#if INTERFACE_USB
-	cinit(BOARD_INTERFACE_CONFIG_USB, USB);
-#endif
-
-
 
 	/* 
 	 * Check the force-bootloader register; if we find the signature there, don't
@@ -632,6 +623,15 @@ main(void)
 		/* booting failed, stay in the bootloader forever */
 		timeout = 0;
 	}
+
+
+	/* start the interface */
+#if INTERFACE_USART
+	cinit(BOARD_INTERFACE_CONFIG_USART, USART);
+#endif
+#if INTERFACE_USB
+	cinit(BOARD_INTERFACE_CONFIG_USB, USB);
+#endif
 
 
 #if 0

--- a/main_f4.c
+++ b/main_f4.c
@@ -283,7 +283,7 @@ board_init(void)
   rcc_peripheral_enable_clock(&BOARD_USART_PIN_CLOCK_REGISTER, BOARD_USART_PIN_CLOCK_BIT);
 
   /* Setup GPIO pins for USART transmit. */
-  gpio_mode_setup(BOARD_PORT_USART, GPIO_MODE_AF, GPIO_PUPD_NONE, BOARD_PIN_TX | BOARD_PIN_RX);
+  gpio_mode_setup(BOARD_PORT_USART, GPIO_MODE_AF, GPIO_PUPD_PULLUP, BOARD_PIN_TX | BOARD_PIN_RX);
   /* Setup USART TX & RX pins as alternate function. */
   gpio_set_af(BOARD_PORT_USART, BOARD_PORT_USART_AF, BOARD_PIN_TX);
   gpio_set_af(BOARD_PORT_USART, BOARD_PORT_USART_AF, BOARD_PIN_RX);

--- a/uart.h
+++ b/uart.h
@@ -43,3 +43,6 @@ extern void uart_cinit(void *config);
 extern void uart_cfini(void);
 extern int uart_cin(void);
 extern void uart_cout(uint8_t *buf, unsigned len);
+extern void uart_break_detect_enable(bool enable);
+extern void uart_send_break();
+extern bool uart_break_detected();

--- a/uart.h
+++ b/uart.h
@@ -43,6 +43,3 @@ extern void uart_cinit(void *config);
 extern void uart_cfini(void);
 extern int uart_cin(void);
 extern void uart_cout(uint8_t *buf, unsigned len);
-extern void uart_break_detect_enable(bool enable);
-extern void uart_send_break();
-extern bool uart_break_detected();

--- a/usart.c
+++ b/usart.c
@@ -36,6 +36,7 @@
 #include <libopencm3/stm32/usart.h>
 
 #include "bl.h"
+#include "uart.h"
 
 uint32_t usart;
 
@@ -54,6 +55,8 @@ uart_cinit(void *config)
         usart_set_mode(usart, USART_MODE_TX_RX);
         usart_set_parity(usart, USART_PARITY_NONE);
         usart_set_flow_control(usart, USART_FLOWCONTROL_NONE);
+
+        uart_break_detect_enable(true);
 
         /* and enable */
         usart_enable(usart);
@@ -85,7 +88,9 @@ uart_cin(void)
 	int c = -1;
 
 	if (USART_SR(usart) & USART_SR_RXNE)
+	{
 		c = usart_recv(usart);
+	}
 	return c;
 }
 
@@ -93,6 +98,39 @@ void
 uart_cout(uint8_t *buf, unsigned len)
 {
 	while (len--)
+	{
 		usart_send_blocking(usart, *buf++);
+	}
 }
 
+void
+uart_break_detect_enable(bool enable)
+{
+	if(enable)
+	{
+		USART_CR2(usart) |= USART_CR2_LINEN;
+	}
+	else
+	{
+		USART_CR2(usart) &= ~USART_CR2_LINEN;
+	}
+}
+
+void
+uart_send_break()
+{
+	USART_CR1(usart) |= USART_CR1_SBK;
+}
+
+
+bool
+uart_break_detected()
+{
+	if(USART_SR(usart) & USART_SR_LBD)
+	{
+		USART_SR(usart) &= ~USART_SR_LBD;
+		return true;
+	}
+
+	return false;
+}

--- a/usart.c
+++ b/usart.c
@@ -56,8 +56,6 @@ uart_cinit(void *config)
         usart_set_parity(usart, USART_PARITY_NONE);
         usart_set_flow_control(usart, USART_FLOWCONTROL_NONE);
 
-        uart_break_detect_enable(true);
-
         /* and enable */
         usart_enable(usart);
 
@@ -101,36 +99,4 @@ uart_cout(uint8_t *buf, unsigned len)
 	{
 		usart_send_blocking(usart, *buf++);
 	}
-}
-
-void
-uart_break_detect_enable(bool enable)
-{
-	if(enable)
-	{
-		USART_CR2(usart) |= USART_CR2_LINEN;
-	}
-	else
-	{
-		USART_CR2(usart) &= ~USART_CR2_LINEN;
-	}
-}
-
-void
-uart_send_break()
-{
-	USART_CR1(usart) |= USART_CR1_SBK;
-}
-
-
-bool
-uart_break_detected()
-{
-	if(USART_SR(usart) & USART_SR_LBD)
-	{
-		USART_SR(usart) &= ~USART_SR_LBD;
-		return true;
-	}
-
-	return false;
 }


### PR DESCRIPTION
@davids5: I have updated my pull request for parallel USB and USART bootloading to be in line with the changes that you made to have a single hw_config file.

I don't have a Pixhawk on hand to test the USART bootloading on that board, so please bear this in mind before merging it in - I have put the USART port on USART2 for the Pixhawk. I have tested the USB and USART for the Px4FMU, though.

Here is a quick overview of the changes:

* In the bl.c file I have now changed the bootloader function to accept both the timeout and the bootloader type (either USART or USB) . This option will then set the appropriate functions cin_usb or cin_usart and cout_usb or cout_usart to the function pointers cin and cout. 

* I have changed the #ifdef INTERFACE_USART to be #if INTERFACE_USART. I don't know whether you have a strong opinion on this?

* In order to accommodate the ability to have parallel USB and USART bootload ability, I have had to add some more variables to the main_f4.c file. These are to tell you whether you should try to boot from the USB bootloader or the USART bootloader.

* I have also now given the bootloader an int return type. If it returns 0, it means an app has been uploaded successfully and you can try to boot. If it returns -1, it means that the bootloader has timed-out.

The basic flow of the main program is as follows.
* Enters main.
* If boot signature not set or the USB not connected, try to jump to the app immediately.
* If jumping to the app failed, try the USART bootloader forever.
* If the USB is connected, don't try to boot and try the USB bootloader. If timed-out, try to boot like usual.
* If the USB is disconnected and the boot signature is set, try the USART bootloader.
* If the USB is connected AND the boot signature is set, don't try to boot, then first try the USB bootloader. If you timeout try the USART bootloader. If an app was successfully uploaded by the USB bootloader, it will try to jump_to the_app. If that fails it will then try the USART bootloader.

I have seen that someone has requested the ability to bootload via the USART in issue #33. I am concerned that they might want to bootload via a wireless connection. If this is the case then we would have to add logic to handle bit and byte drops. I don't know whether this is necessary to do at this time. This would slow down the uploading of firmware a bit, so maybe there should be logic so that it only does bit and byte drop checking and compensation if it is bootloading over the USART port. Thoughts? 
