### PR TITLE
[PX4_DISCOVERY_V1] Windows lingering to answer bootloader.

### DIFF
--- a/cdcacm.c
+++ b/cdcacm.c
@@ -193,25 +193,12 @@ static const struct usb_config_descriptor config = {
 	.interface = ifaces,
 };
 
-static const struct usb_cdc_line_coding get_line_coding = {
-	.dwDTERate = 115200,
-	.bCharFormat = USB_CDC_1_STOP_BITS,
-	.bParityType = USB_CDC_NO_PARITY,
-	.bDataBits = 0x08
-};
-
-#define USB_CDC_REQ_GET_LINE_CODING  0x21 // do not implemented in libopencm3?
-
-//static int cdcacm_control_request(usbd_device *usbd_dev, struct usb_setup_data *req, uint8_t **buf,
-//  uint16_t *len, usbd_control_complete_callback *complete)
 static int cdcacm_control_request(usbd_device *usbd_dev, struct usb_setup_data *req, uint8_t **buf,
 		uint16_t *len, void (**complete)(usbd_device *usbd_dev, struct usb_setup_data *req))
 {
 	(void)complete;
-	//(void)buf;
+	(void)buf;
 	(void)usbd_dev;
-
-	*buf = NULL;
 
 	switch (req->bRequest) {
 	case USB_CDC_REQ_SET_CONTROL_LINE_STATE: {
@@ -226,9 +213,6 @@ static int cdcacm_control_request(usbd_device *usbd_dev, struct usb_setup_data *
 		if (*len < sizeof(struct usb_cdc_line_coding))
 			return 0;
 
-		return 1;
-	case USB_CDC_REQ_GET_LINE_CODING:
-		*buf = &get_line_coding;
 		return 1;
 	}
 	return 0;

--- a/cdcacm.c
+++ b/cdcacm.c
@@ -193,12 +193,25 @@ static const struct usb_config_descriptor config = {
 	.interface = ifaces,
 };
 
+static const struct usb_cdc_line_coding get_line_coding = {
+	.dwDTERate = 115200,
+	.bCharFormat = USB_CDC_1_STOP_BITS,
+	.bParityType = USB_CDC_NO_PARITY,
+	.bDataBits = 0x08
+};
+
+#define USB_CDC_REQ_GET_LINE_CODING  0x21 // do not implemented in libopencm3?
+
+//static int cdcacm_control_request(usbd_device *usbd_dev, struct usb_setup_data *req, uint8_t **buf,
+//  uint16_t *len, usbd_control_complete_callback *complete)
 static int cdcacm_control_request(usbd_device *usbd_dev, struct usb_setup_data *req, uint8_t **buf,
 		uint16_t *len, void (**complete)(usbd_device *usbd_dev, struct usb_setup_data *req))
 {
 	(void)complete;
-	(void)buf;
+	//(void)buf;
 	(void)usbd_dev;
+
+	*buf = NULL;
 
 	switch (req->bRequest) {
 	case USB_CDC_REQ_SET_CONTROL_LINE_STATE: {
@@ -213,6 +226,9 @@ static int cdcacm_control_request(usbd_device *usbd_dev, struct usb_setup_data *
 		if (*len < sizeof(struct usb_cdc_line_coding))
 			return 0;
 
+		return 1;
+	case USB_CDC_REQ_GET_LINE_CODING:
+		*buf = &get_line_coding;
 		return 1;
 	}
 	return 0;

--- a/cdcacm.c
+++ b/cdcacm.c
@@ -193,12 +193,22 @@ static const struct usb_config_descriptor config = {
 	.interface = ifaces,
 };
 
+static const struct usb_cdc_line_coding line_coding = {
+	.dwDTERate = 115200,
+	.bCharFormat = USB_CDC_1_STOP_BITS,
+	.bParityType = USB_CDC_NO_PARITY,
+	.bDataBits = 0x08
+};
+
+#define USB_CDC_REQ_GET_LINE_CODING  0x21 /* do not implemented in libopencm3? */
+
 static int cdcacm_control_request(usbd_device *usbd_dev, struct usb_setup_data *req, uint8_t **buf,
 		uint16_t *len, void (**complete)(usbd_device *usbd_dev, struct usb_setup_data *req))
 {
 	(void)complete;
-	(void)buf;
 	(void)usbd_dev;
+
+	*buf = NULL;
 
 	switch (req->bRequest) {
 	case USB_CDC_REQ_SET_CONTROL_LINE_STATE: {
@@ -213,6 +223,9 @@ static int cdcacm_control_request(usbd_device *usbd_dev, struct usb_setup_data *
 		if (*len < sizeof(struct usb_cdc_line_coding))
 			return 0;
 
+		return 1;
+	case USB_CDC_REQ_GET_LINE_CODING:
+		*buf = (uint8_t *)&line_coding;
 		return 1;
 	}
 	return 0;


### PR DESCRIPTION
In windows seven takes too long to answer the bootloader and the old firmware ends up being loaded. Using the program "USBPcapCMD" and "Wireshark" to capture the usb packet, i found that there are many requests "GET LINE CODING REQUEST", being the cause of the delay. Note: English is not my native language if what I wrote is not clear (I used the google translator).

The following image capture
![cap](https://cloud.githubusercontent.com/assets/9913906/10265167/e9227f38-69fa-11e5-9765-9217ce28f2ea.jpg)
