### PR TITLE
Fix MAVStation USB bootloader

### DIFF
--- a/hw_config.h
+++ b/hw_config.h
@@ -307,7 +307,7 @@
 # define BOOTLOADER_DELAY               3000
 # define BOARD_MAVSTATION
 # define INTERFACE_USB                  1
-# define INTERFACE_USART                0
+# define INTERFACE_USART                1
 # define USBDEVICESTRING                "MAVSTATION BL v0.1"
 # define USBPRODUCTID                   0x0014
 

--- a/hw_config.h
+++ b/hw_config.h
@@ -327,8 +327,8 @@
 # define BOARD_USART_CLOCK_BIT          RCC_APB1ENR_USART2EN
 
 # define BOARD_PORT_USART               GPIOA
-# define BOARD_PIN_TX                   GPIO_USART1_TX
-# define BOARD_PIN_RX                   GPIO_USART1_RX
+# define BOARD_PIN_TX                   GPIO_USART2_TX
+# define BOARD_PIN_RX                   GPIO_USART2_RX
 # define BOARD_USART_PIN_CLOCK_REGISTER RCC_APB2ENR
 # define BOARD_USART_PIN_CLOCK_BIT      RCC_APB2ENR_IOPAEN
 

--- a/main_f1.c
+++ b/main_f1.c
@@ -129,11 +129,7 @@ board_deinit(void)
 static inline void
 clock_init(void)
 {
-#if INTERFACE_USB
 	rcc_clock_setup_in_hsi_out_48mhz();
-#else
-	rcc_clock_setup_in_hsi_out_24mhz();
-#endif
 }
 
 /**

--- a/main_f1.c
+++ b/main_f1.c
@@ -20,11 +20,12 @@
 // address of MCU IDCODE
 #define DBGMCU_IDCODE		0xE0042000
 
-
-#ifdef INTERFACE_USART
-# define BOARD_INTERFACE_CONFIG		(void *)BOARD_USART
-#else
-# define BOARD_INTERFACE_CONFIG		NULL
+/* context passed to cinit */
+#if INTERFACE_USART
+# define BOARD_INTERFACE_CONFIG_USART	(void *)BOARD_USART
+#endif
+#if INTERFACE_USB
+# define BOARD_INTERFACE_CONFIG_USB  	NULL
 #endif
 
 /* board definition */
@@ -128,7 +129,7 @@ board_deinit(void)
 static inline void
 clock_init(void)
 {
-#if defined(INTERFACE_USB)
+#if INTERFACE_USB
 	rcc_clock_setup_in_hsi_out_48mhz();
 #else
 	rcc_clock_setup_in_hsi_out_24mhz();
@@ -304,7 +305,7 @@ main(void)
 	/* do board-specific initialisation */
 	board_init();
 
-#if defined(INTERFACE_USART) | defined (INTERFACE_USB)
+#if INTERFACE_USART || INTERFACE_USB
 	/* XXX sniff for a USART connection to decide whether to wait in the bootloader? */
 	timeout = BOOTLOADER_DELAY;
 #endif
@@ -343,7 +344,12 @@ main(void)
 	clock_init();
 
 	/* start the interface */
-	cinit(BOARD_INTERFACE_CONFIG, USART);
+#if INTERFACE_USART
+	cinit(BOARD_INTERFACE_CONFIG_USART, USART);
+#endif
+#if INTERFACE_USB
+	cinit(BOARD_INTERFACE_CONFIG_USB, USB);
+#endif
 
 	while (1) {
 		/* run the bootloader, possibly coming back after the timeout */


### PR DESCRIPTION
The MAVStation USB bootloader was accidentally killed by the introduction
of the dual USB and USART bootloader.
