### PR TITLE
Adds readout of the chip's serial number in the STM32F1 bootloaders

### DIFF
--- a/main_f1.c
+++ b/main_f1.c
@@ -15,10 +15,7 @@
 
 #include "bl.h"
 
-/*
- * Yes, the nonsense required to configure GPIOs with this
- * library is truly insane...
- */
+#define UDID_START      0x1FFFF7E8
 
 
 #ifdef INTERFACE_USART
@@ -204,10 +201,13 @@ flash_func_read_otp(uint32_t address)
 {
 	return 0;
 }
+
 uint32_t
 flash_func_read_sn(uint32_t address)
 {
-	return 0;
+	// read a byte out from unique chip ID area
+  	// it's 12 bytes, or 3 words.
+  	return *(uint32_t *)(address + UDID_START);
 }
 
 void


### PR DESCRIPTION
Previously the SMT32F1 devices just returned 0 when queried for their serial numbers. This might be useful for the MAVStation board. It will then return the serial number to the px_uploader like what is done with PX4FMU and the PIXHAWK. This might also be useful for the PXIO uploader, if it needs to get the serial from a chip that has bad firmware.