### PR TITLE
WIP - Do not merge: Wireless bootloading

### DIFF
--- a/px_uploader.py
+++ b/px_uploader.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 ############################################################################
 #
-#   Copyright (C) 2012, 2013 PX4 Development Team. All rights reserved.
+#   Copyright (C) 2012-2015 PX4 Development Team. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -33,5 +33,651 @@
 ############################################################################
 
 #
-print("This version of the px_uploader script has been depreciated!")
-print("Please use https://github.com/PX4/Firmware/blob/master/Tools/px_uploader.py")
+# Serial firmware uploader for the PX4FMU bootloader
+#
+# The PX4 firmware file is a JSON-encoded Python object, containing
+# metadata fields and a zlib-compressed base64-encoded firmware image.
+#
+# The uploader uses the following fields from the firmware file:
+#
+# image
+#       The firmware that will be uploaded.
+# image_size
+#       The size of the firmware in bytes.
+# board_id
+#       The board for which the firmware is intended.
+# board_revision
+#       Currently only used for informational purposes.
+#
+
+# for python2.7 compatibility
+from __future__ import print_function
+
+import sys
+import argparse
+import binascii
+import serial
+import struct
+import json
+import zlib
+import base64
+import time
+import array
+import os
+
+from sys import platform as _platform
+
+
+class firmware(object):
+        '''Loads a firmware file'''
+
+        desc = {}
+        image = bytes()
+        crctab = array.array('I', [
+            0x00000000, 0x77073096, 0xee0e612c, 0x990951ba, 0x076dc419, 0x706af48f, 0xe963a535, 0x9e6495a3,
+            0x0edb8832, 0x79dcb8a4, 0xe0d5e91e, 0x97d2d988, 0x09b64c2b, 0x7eb17cbd, 0xe7b82d07, 0x90bf1d91,
+            0x1db71064, 0x6ab020f2, 0xf3b97148, 0x84be41de, 0x1adad47d, 0x6ddde4eb, 0xf4d4b551, 0x83d385c7,
+            0x136c9856, 0x646ba8c0, 0xfd62f97a, 0x8a65c9ec, 0x14015c4f, 0x63066cd9, 0xfa0f3d63, 0x8d080df5,
+            0x3b6e20c8, 0x4c69105e, 0xd56041e4, 0xa2677172, 0x3c03e4d1, 0x4b04d447, 0xd20d85fd, 0xa50ab56b,
+            0x35b5a8fa, 0x42b2986c, 0xdbbbc9d6, 0xacbcf940, 0x32d86ce3, 0x45df5c75, 0xdcd60dcf, 0xabd13d59,
+            0x26d930ac, 0x51de003a, 0xc8d75180, 0xbfd06116, 0x21b4f4b5, 0x56b3c423, 0xcfba9599, 0xb8bda50f,
+            0x2802b89e, 0x5f058808, 0xc60cd9b2, 0xb10be924, 0x2f6f7c87, 0x58684c11, 0xc1611dab, 0xb6662d3d,
+            0x76dc4190, 0x01db7106, 0x98d220bc, 0xefd5102a, 0x71b18589, 0x06b6b51f, 0x9fbfe4a5, 0xe8b8d433,
+            0x7807c9a2, 0x0f00f934, 0x9609a88e, 0xe10e9818, 0x7f6a0dbb, 0x086d3d2d, 0x91646c97, 0xe6635c01,
+            0x6b6b51f4, 0x1c6c6162, 0x856530d8, 0xf262004e, 0x6c0695ed, 0x1b01a57b, 0x8208f4c1, 0xf50fc457,
+            0x65b0d9c6, 0x12b7e950, 0x8bbeb8ea, 0xfcb9887c, 0x62dd1ddf, 0x15da2d49, 0x8cd37cf3, 0xfbd44c65,
+            0x4db26158, 0x3ab551ce, 0xa3bc0074, 0xd4bb30e2, 0x4adfa541, 0x3dd895d7, 0xa4d1c46d, 0xd3d6f4fb,
+            0x4369e96a, 0x346ed9fc, 0xad678846, 0xda60b8d0, 0x44042d73, 0x33031de5, 0xaa0a4c5f, 0xdd0d7cc9,
+            0x5005713c, 0x270241aa, 0xbe0b1010, 0xc90c2086, 0x5768b525, 0x206f85b3, 0xb966d409, 0xce61e49f,
+            0x5edef90e, 0x29d9c998, 0xb0d09822, 0xc7d7a8b4, 0x59b33d17, 0x2eb40d81, 0xb7bd5c3b, 0xc0ba6cad,
+            0xedb88320, 0x9abfb3b6, 0x03b6e20c, 0x74b1d29a, 0xead54739, 0x9dd277af, 0x04db2615, 0x73dc1683,
+            0xe3630b12, 0x94643b84, 0x0d6d6a3e, 0x7a6a5aa8, 0xe40ecf0b, 0x9309ff9d, 0x0a00ae27, 0x7d079eb1,
+            0xf00f9344, 0x8708a3d2, 0x1e01f268, 0x6906c2fe, 0xf762575d, 0x806567cb, 0x196c3671, 0x6e6b06e7,
+            0xfed41b76, 0x89d32be0, 0x10da7a5a, 0x67dd4acc, 0xf9b9df6f, 0x8ebeeff9, 0x17b7be43, 0x60b08ed5,
+            0xd6d6a3e8, 0xa1d1937e, 0x38d8c2c4, 0x4fdff252, 0xd1bb67f1, 0xa6bc5767, 0x3fb506dd, 0x48b2364b,
+            0xd80d2bda, 0xaf0a1b4c, 0x36034af6, 0x41047a60, 0xdf60efc3, 0xa867df55, 0x316e8eef, 0x4669be79,
+            0xcb61b38c, 0xbc66831a, 0x256fd2a0, 0x5268e236, 0xcc0c7795, 0xbb0b4703, 0x220216b9, 0x5505262f,
+            0xc5ba3bbe, 0xb2bd0b28, 0x2bb45a92, 0x5cb36a04, 0xc2d7ffa7, 0xb5d0cf31, 0x2cd99e8b, 0x5bdeae1d,
+            0x9b64c2b0, 0xec63f226, 0x756aa39c, 0x026d930a, 0x9c0906a9, 0xeb0e363f, 0x72076785, 0x05005713,
+            0x95bf4a82, 0xe2b87a14, 0x7bb12bae, 0x0cb61b38, 0x92d28e9b, 0xe5d5be0d, 0x7cdcefb7, 0x0bdbdf21,
+            0x86d3d2d4, 0xf1d4e242, 0x68ddb3f8, 0x1fda836e, 0x81be16cd, 0xf6b9265b, 0x6fb077e1, 0x18b74777,
+            0x88085ae6, 0xff0f6a70, 0x66063bca, 0x11010b5c, 0x8f659eff, 0xf862ae69, 0x616bffd3, 0x166ccf45,
+            0xa00ae278, 0xd70dd2ee, 0x4e048354, 0x3903b3c2, 0xa7672661, 0xd06016f7, 0x4969474d, 0x3e6e77db,
+            0xaed16a4a, 0xd9d65adc, 0x40df0b66, 0x37d83bf0, 0xa9bcae53, 0xdebb9ec5, 0x47b2cf7f, 0x30b5ffe9,
+            0xbdbdf21c, 0xcabac28a, 0x53b39330, 0x24b4a3a6, 0xbad03605, 0xcdd70693, 0x54de5729, 0x23d967bf,
+            0xb3667a2e, 0xc4614ab8, 0x5d681b02, 0x2a6f2b94, 0xb40bbe37, 0xc30c8ea1, 0x5a05df1b, 0x2d02ef8d])
+        crcpad = bytearray(b'\xff\xff\xff\xff')
+
+        def __init__(self, path):
+
+                # read the file
+                f = open(path, "r")
+                self.desc = json.load(f)
+                f.close()
+
+                self.image = bytearray(zlib.decompress(base64.b64decode(self.desc['image'])))
+
+                # pad image to 4-byte length
+                while ((len(self.image) % 4) != 0):
+                        self.image.append('\xff')
+
+        def property(self, propname):
+                return self.desc[propname]
+
+        @staticmethod
+        def crc32(bytes, state):
+                for byte in bytes:
+                        index = (state ^ byte) & 0xff
+                        state = firmware.crctab[index] ^ (state >> 8)
+                return state
+
+        def crc(self, padlen):
+                state = self.crc32(self.image, int(0))
+                for i in range(len(self.image), (padlen - 1), 4):
+                        state = self.crc32(self.crcpad, state)
+                return state
+
+
+class uploader(object):
+        '''Uploads a firmware file to the PX FMU bootloader'''
+
+        # protocol bytes
+        INSYNC          = b'\x12'
+        EOC             = b'\x20'
+
+        # reply bytes
+        OK              = b'\x10'
+        FAILED          = b'\x11'
+        INVALID         = b'\x13'     # rev3+
+        BAD_SILICON_REV = b'\x14'     # rev5+
+        BAD_ADDRESS     = b'\x15'     # rev6+
+        BAD_CRC         = b'\x16'     # rev6+
+
+        # command bytes
+        NOP             = b'\x00'     # guaranteed to be discarded by the bootloader
+        GET_SYNC        = b'\x21'
+        GET_DEVICE      = b'\x22'
+        CHIP_ERASE      = b'\x23'
+        CHIP_VERIFY     = b'\x24'     # rev2 only
+        PROG_MULTI      = b'\x27'
+        READ_MULTI      = b'\x28'     # rev2 only
+        GET_CRC         = b'\x29'     # rev3+
+        GET_OTP         = b'\x2a'     # rev4+  , get a word from OTP area
+        GET_SN          = b'\x2b'     # rev4+  , get a word from SN area
+        GET_CHIP        = b'\x2c'     # rev5+  , get chip version
+        SET_BOOT_DELAY  = b'\x2d'     # rev5+  , set boot delay
+        GET_CHIP_DES    = b'\x2e'     # rev5+  , get chip description in ASCII
+        MAX_DES_LENGTH  = 20
+
+        REBOOT          = b'\x30'
+        
+        INFO_BL_REV     = b'\x01'        # bootloader protocol revision
+        BL_REV_MIN      = 2              # minimum supported bootloader protocol
+        BL_REV_MAX      = 6              # maximum supported bootloader protocol
+        INFO_BOARD_ID   = b'\x02'        # board type
+        INFO_BOARD_REV  = b'\x03'        # board revision
+        INFO_FLASH_SIZE = b'\x04'        # max firmware size in bytes
+
+        PROG_MULTI_MAX  = 252            # protocol max is 255, must be multiple of 4
+        READ_MULTI_MAX  = 252            # protocol max is 255
+        
+        NSH_INIT        = bytearray(b'\x0d\x0d\x0d')
+        NSH_REBOOT_BL   = b"reboot -b\n"
+        NSH_REBOOT      = b"reboot\n"
+        MAVLINK_REBOOT_ID1 = bytearray(b'\xfe\x21\x72\xff\x00\x4c\x00\x00\x80\x3f\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xf6\x00\x01\x00\x00\x48\xf0')
+        MAVLINK_REBOOT_ID0 = bytearray(b'\xfe\x21\x45\xff\x00\x4c\x00\x00\x80\x3f\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xf6\x00\x00\x00\x00\xd7\xac')
+
+        def __init__(self, portname, baudrate):
+                # open the port, keep the default timeout short so we can poll quickly
+                self.port = serial.Serial(portname, baudrate, timeout=0.5)
+                self.otp = b''
+                self.sn = b''
+                
+                self.current_position = 0;                
+                self.resend_prog_multi = False
+                self.cnt = 0
+
+        def close(self):
+                if self.port is not None:
+                        self.port.close()
+
+        def __send(self, c):
+#               print("send " + binascii.hexlify(c))
+                self.port.write(c)
+
+        def __recv(self, count=1):
+                c = self.port.read(count)
+                if len(c) < 1:
+                        raise RuntimeError("timeout waiting for data (%u bytes)" % count)
+#               print("recv " + binascii.hexlify(c))
+                return c
+
+        def __recv_int(self):
+                raw = self.__recv(4)
+                val = struct.unpack("<I", raw)
+                return val[0]
+
+        def __getSync(self):
+                self.port.flush()
+                c = bytes(self.__recv())
+                if c != self.INSYNC:
+                        raise RuntimeError("unexpected %s instead of INSYNC" % c)
+                c = self.__recv()
+                if c == self.INVALID:
+                        raise RuntimeError("bootloader reports INVALID OPERATION")
+                if c == self.FAILED:
+                        raise RuntimeError("bootloader reports OPERATION FAILED")
+                if c == self.BAD_ADDRESS:                        
+                        c = self.__recv_int()
+                        raise RuntimeError("bootloader reports unexpected address. Address expected was %d " % int(c))
+                if c == self.BAD_CRC:
+                        raise RuntimeError("bootloader reports bad CRC.")                        
+                if c != self.OK:
+                        raise RuntimeError("unexpected response 0x%x instead of OK" % ord(c))
+                    
+
+        # attempt to get back into sync with the bootloader
+        def __sync(self):
+                # send a stream of ignored bytes longer than the longest possible conversation
+                # that we might still have in progress
+#               self.__send(uploader.NOP * (uploader.PROG_MULTI_MAX + 2))
+                self.port.flushInput()
+                self.__send(uploader.GET_SYNC
+                            + uploader.EOC)
+                self.__getSync()
+
+        def __trySync(self):
+                try:
+                    self.port.flush()
+                    if (self.__recv() != self.INSYNC):
+                        #print("unexpected instead of INSYNC")
+                        return False, None;
+                    c = self.__recv()
+                    if (c == self.BAD_SILICON_REV):
+                        raise NotImplementedError()
+                    if c == self.BAD_ADDRESS:      
+                        #print("bad address")  
+                        address = self.__recv_int()
+                        #print("Expected %d" % int(address))                        
+                        return False, address                
+                    if (c != self.OK):
+                        #print("unexpected 0x%x instead of OK" % ord(c))
+                        return False, None
+                    return True, None
+
+                except NotImplementedError:
+                    raise RuntimeError("Programing not supported for this version of silicon!\n See https://pixhawk.org/help/errata")
+                except RuntimeError:
+                    #timeout, no response yet
+                    return False, None
+
+        # send the GET_DEVICE command and wait for an info parameter
+        def __getInfo(self, param):
+                self.__send(uploader.GET_DEVICE + param + uploader.EOC)
+                value = self.__recv_int()
+                self.__getSync()
+                return value
+
+        # send the GET_OTP command and wait for an info parameter
+        def __getOTP(self, param):
+                t = struct.pack("I", param) # int param as 32bit ( 4 byte ) char array.
+                self.__send(uploader.GET_OTP + t + uploader.EOC)
+                value = self.__recv(4)
+                self.__getSync()
+                return value
+
+        # send the GET_SN command and wait for an info parameter
+        def __getSN(self, param):
+                t = struct.pack("I", param) # int param as 32bit ( 4 byte ) char array.
+                self.__send(uploader.GET_SN + t + uploader.EOC)
+                value = self.__recv(4)
+                self.__getSync()
+                return value
+
+        # send the GET_CHIP command
+        def __getCHIP(self):
+                self.__send(uploader.GET_CHIP + uploader.EOC)
+                value = self.__recv_int()
+                self.__getSync()
+                return value
+        # send the GET_CHIP command
+        def __getCHIPDes(self):
+                self.__send(uploader.GET_CHIP_DES + uploader.EOC)
+                length = self.__recv_int()
+                value = self.__recv(length)
+                self.__getSync()
+                peices = value.split(",")
+                return peices
+
+        def __drawProgressBar(self, label, progress, maxVal):
+                if maxVal < progress:
+                    progress = maxVal
+
+                percent = (float(progress) / float(maxVal)) * 100.0
+
+                sys.stdout.write("\r%s: [%-20s] %.1f%%" % (label, '='*int(percent/5.0), percent))
+                sys.stdout.flush()
+
+
+        # send the CHIP_ERASE command and wait for the bootloader to become ready
+        def __erase(self, label):
+                print("\n", end='')
+                self.__send(uploader.CHIP_ERASE
+                            + uploader.EOC)
+
+                # erase is very slow, give it 20s
+                deadline = time.time() + 20.0
+                while time.time() < deadline:
+
+                        #Draw progress bar (erase usually takes about 9 seconds to complete)
+                        estimatedTimeRemaining = deadline-time.time()
+                        if estimatedTimeRemaining >= 9.0:
+                            self.__drawProgressBar(label, 20.0-estimatedTimeRemaining, 9.0)
+                        else:
+                            self.__drawProgressBar(label, 10.0, 10.0)
+                            sys.stdout.write(" (timeout: %d seconds) " % int(deadline-time.time()) )
+                            sys.stdout.flush()
+
+                        ret, address = self.__trySync()
+                        if ret:
+                            self.__drawProgressBar(label, 10.0, 10.0)
+                            return;
+
+                raise RuntimeError("timed out waiting for erase")
+
+        # send a PROG_MULTI command to write a collection of bytes
+        def __program_multi(self, position, data):
+                                
+                if runningPython3 == True:
+                    length = len(data).to_bytes(1, byteorder='big')
+                else:
+                    length = chr(len(data))
+                                         
+                # Give it 5 seconds to try and send the data before final timeout
+                deadline = time.time() + 5.0
+                while time.time() < deadline:
+                    self.cnt += 1
+                    self.__send(uploader.PROG_MULTI)
+                    if self.bl_rev >= 6:                        
+                        self.__send(struct.pack("<I", position))
+                    self.__send(length)
+                    self.__send(data)
+                    if self.bl_rev >= 6:
+                        crc = firmware.crc32(data, 0)                        
+                        self.__send(struct.pack("<I", crc))
+                    self.__send(uploader.EOC)
+                    
+                    
+                    if self.bl_rev >= 6:
+                        # Try and get the sync. If it times out, continue and resend the message
+                        ret, address = self.__trySync()                        
+                        if ret:                            
+                            return
+                        else:
+                            # Check if the error was caused by the address being incorrect
+                            if address is not None:                                
+                                print("Bad address. Expected %d, current %d", int(address), int(position))
+                                # If the address returned by the bootloader is larger than what we are sending, then it probably has already programmed the data, but we didn't get the response 
+                                if address > position:
+                                    return                                                                               
+                    else: 
+                        self.__getSync()
+                        return
+                                                            
+                raise RuntimeError("timed out trying to program")
+                    
+
+        # verify multiple bytes in flash
+        def __verify_multi(self, data):
+            
+                if runningPython3 == True:
+                    length = len(data).to_bytes(1, byteorder='big')
+                else:
+                    length = chr(len(data))
+                
+                self.__send(uploader.READ_MULTI)
+                self.__send(length)
+                self.__send(uploader.EOC)
+                self.port.flush()
+                programmed = self.__recv(len(data))
+                if programmed != data:
+                        print("got    " + binascii.hexlify(programmed))
+                        print("expect " + binascii.hexlify(data))
+                        return False
+                self.__getSync()
+                return True
+
+        # send the reboot command
+        def __reboot(self):
+                self.__send(uploader.REBOOT
+                            + uploader.EOC)
+                self.port.flush()
+
+                # v3+ can report failure if the first word flash fails
+                if self.bl_rev >= 3:
+                        self.__getSync()
+
+        # split a sequence into a list of size-constrained pieces
+        def __split_len(self, seq, length):
+                return [seq[i:i+length] for i in range(0, len(seq), length)]
+
+        # upload code
+        def __program(self, label, fw):
+                print("\n", end='')
+                code = fw.image
+                groups = self.__split_len(code, uploader.PROG_MULTI_MAX)
+
+                uploadProgress = 0
+                for bytes in groups:                        
+                        self.__program_multi(self.current_position, bytes)
+                        self.current_position += len(bytes);
+                        
+                        #Print upload progress (throttled, so it does not delay upload progress)
+                        uploadProgress += 1
+                        if uploadProgress % 256 == 0:
+                            self.__drawProgressBar(label, uploadProgress, len(groups))
+                self.__drawProgressBar(label, 100, 100)
+
+        # verify code
+        def __verify_v2(self, label, fw):
+                print("\n", end='')
+                self.__send(uploader.CHIP_VERIFY
+                            + uploader.EOC)
+                self.__getSync()
+                code = fw.image
+                groups = self.__split_len(code, uploader.READ_MULTI_MAX)
+                verifyProgress = 0
+                for bytes in groups:
+                        verifyProgress += 1
+                        if verifyProgress % 256 == 0:
+                            self.__drawProgressBar(label, verifyProgress, len(groups))
+                        if (not self.__verify_multi(bytes)):
+                                raise RuntimeError("Verification failed")
+                self.__drawProgressBar(label, 100, 100)
+
+        def __verify_v3(self, label, fw):
+                print("\n", end='')
+                self.__drawProgressBar(label, 1, 100)
+                expect_crc = fw.crc(self.fw_maxsize)                
+                self.__send(uploader.GET_CRC
+                            + uploader.EOC)
+                report_crc = self.__recv_int()
+                self.__getSync()
+                verifyProgress = 0
+                if report_crc != expect_crc:
+                        print("Expected 0x%x" % expect_crc)
+                        print("Got      0x%x" % report_crc)
+                        raise RuntimeError("Program CRC failed")
+                self.__drawProgressBar(label, 100, 100)
+
+        def __set_boot_delay(self, boot_delay):
+                self.__send(uploader.SET_BOOT_DELAY
+                            + struct.pack("b", boot_delay)
+                            + uploader.EOC)
+                self.__getSync()
+
+        # get basic data about the board
+        def identify(self):
+                # make sure we are in sync before starting
+                self.__sync()
+
+                # get the bootloader protocol ID first
+                self.bl_rev = self.__getInfo(uploader.INFO_BL_REV)
+                if (self.bl_rev < uploader.BL_REV_MIN) or (self.bl_rev > uploader.BL_REV_MAX):
+                        print("Unsupported bootloader protocol %d" % uploader.INFO_BL_REV)
+                        raise RuntimeError("Bootloader protocol mismatch")
+
+                self.board_type = self.__getInfo(uploader.INFO_BOARD_ID)
+                self.board_rev = self.__getInfo(uploader.INFO_BOARD_REV)
+                self.fw_maxsize = self.__getInfo(uploader.INFO_FLASH_SIZE)
+
+        # upload the firmware
+        def upload(self, fw):
+                # Make sure we are doing the right thing
+                if self.board_type != fw.property('board_id'):
+                        msg = "Firmware not suitable for this board (board_type=%u board_id=%u)" % (
+                                self.board_type, fw.property('board_id'))
+                        if args.force:
+                                print("WARNING: %s" % msg)
+                        else:
+                                raise IOError(msg)
+                if self.fw_maxsize < fw.property('image_size'):
+                        raise RuntimeError("Firmware image is too large for this board")
+
+                # OTP added in v4:
+                if self.bl_rev > 3:
+                    for byte in range(0,32*6,4):
+                        x = self.__getOTP(byte)
+                        self.otp  = self.otp + x
+                        print(binascii.hexlify(x).decode('Latin-1') + ' ', end='')
+                    # see src/modules/systemlib/otp.h in px4 code:
+                    self.otp_id = self.otp[0:4]
+                    self.otp_idtype = self.otp[4:5]
+                    self.otp_vid = self.otp[8:4:-1]
+                    self.otp_pid = self.otp[12:8:-1]
+                    self.otp_coa = self.otp[32:160]
+                    # show user:
+                    try:
+                            print("type: " + self.otp_id.decode('Latin-1'))
+                            print("idtype: " + binascii.b2a_qp(self.otp_idtype).decode('Latin-1'))
+                            print("vid: " + binascii.hexlify(self.otp_vid).decode('Latin-1'))
+                            print("pid: "+ binascii.hexlify(self.otp_pid).decode('Latin-1'))
+                            print("coa: "+ binascii.b2a_base64(self.otp_coa).decode('Latin-1'))
+                            print("sn: ", end='')
+                            for byte in range(0,12,4):
+                                    x = self.__getSN(byte)
+                                    x = x[::-1]  # reverse the bytes
+                                    self.sn  = self.sn + x
+                                    print(binascii.hexlify(x).decode('Latin-1'), end='') # show user
+                            print('')
+                            print("chip: %08x" % self.__getCHIP())
+                            if (self.bl_rev >= 5):
+                                des = self.__getCHIPDes()
+                                if (len(des) == 2):
+                                    print("family: %s" % des[0])
+                                    print("revision: %s" % des[1])
+                                    print("flash %d" % self.fw_maxsize)
+                    except Exception:
+                            # ignore bad character encodings
+                            pass
+                
+                self.__erase("Erase  ")                
+                self.__program("Program", fw)
+
+                if self.bl_rev == 2:
+                        self.__verify_v2("Verify ", fw)
+                else:
+                        self.__verify_v3("Verify ", fw)
+
+                if args.boot_delay is not None:
+                        self.__set_boot_delay(args.boot_delay)
+
+                print("\nRebooting.\n")
+                self.__reboot()
+                self.port.close()
+                
+        def send_reboot(self):
+                try:
+                    # try reboot via NSH first
+                    self.__send(uploader.NSH_INIT)
+                    self.__send(uploader.NSH_REBOOT_BL)
+                    self.__send(uploader.NSH_INIT)
+                    self.__send(uploader.NSH_REBOOT)
+                    # then try MAVLINK command
+                    self.__send(uploader.MAVLINK_REBOOT_ID1)
+                    self.__send(uploader.MAVLINK_REBOOT_ID0)
+                except:
+                    return
+
+
+# Detect python version
+if sys.version_info[0] < 3:
+    runningPython3 = False
+else:
+    runningPython3 = True
+
+# Parse command line arguments
+parser = argparse.ArgumentParser(description="Firmware uploader for the PX autopilot system.")
+parser.add_argument('--port', action="store", required=True, help="Serial port(s) to which the FMU may be attached")
+parser.add_argument('--baud', action="store", type=int, default=115200, help="Baud rate of the serial port (default is 115200), only required for true serial ports.")
+parser.add_argument('--force', action='store_true', default=False, help='Override board type check and continue loading')
+parser.add_argument('--boot-delay', type=int, default=None, help='minimum boot delay to store in flash')
+parser.add_argument('firmware', action="store", help="Firmware file to be uploaded")
+args = parser.parse_args()
+
+# warn people about ModemManager which interferes badly with Pixhawk
+if os.path.exists("/usr/sbin/ModemManager"):
+        print("==========================================================================================================")
+        print("WARNING: You should uninstall ModemManager as it conflicts with any non-modem serial device (like Pixhawk)")
+        print("==========================================================================================================")
+
+# Load the firmware file
+fw = firmware(args.firmware)
+print("Loaded firmware for %x,%x, size: %d bytes, waiting for the bootloader..." % (fw.property('board_id'), fw.property('board_revision'), fw.property('image_size')))
+print("If the board does not respond within 1-2 seconds, unplug and re-plug the USB connector.")
+
+# Spin waiting for a device to show up
+try:
+    while True:
+            portlist = []
+            patterns = args.port.split(",")
+            # on unix-like platforms use glob to support wildcard ports. This allows
+            # the use of /dev/serial/by-id/usb-3D_Robotics on Linux, which prevents the upload from
+            # causing modem hangups etc
+            if "linux" in _platform or "darwin" in _platform:
+                    import glob
+                    for pattern in patterns:
+                            portlist += glob.glob(pattern)
+            else:
+                    portlist = patterns
+
+            for port in portlist:
+
+                    #print("Trying %s" % port)
+
+                    # create an uploader attached to the port
+                    try:
+                            if "linux" in _platform:
+                            # Linux, don't open Mac OS and Win ports
+                                    if not "COM" in port and not "tty.usb" in port:
+                                            up = uploader(port, args.baud)
+                            elif "darwin" in _platform:
+                                    # OS X, don't open Windows and Linux ports
+                                    if not "COM" in port and not "ACM" in port:
+                                            up = uploader(port, args.baud)
+                            elif "win" in _platform:
+                                    # Windows, don't open POSIX ports
+                                    if not "/" in port:
+                                            up = uploader(port, args.baud)
+                    except Exception:
+                            # open failed, rate-limit our attempts
+                            time.sleep(0.05)
+
+                            # and loop to the next port
+                            continue
+
+                    # port is open, try talking to it
+                    try:
+                            # identify the bootloader
+                            up.identify()
+                            print("Found board %x,%x bootloader rev %x on %s" % (up.board_type, up.board_rev, up.bl_rev, port))
+
+                    except Exception:
+                            # most probably a timeout talking to the port, no bootloader, try to reboot the board
+                            print("attempting reboot on %s..." % port)
+                            print("if the board does not respond, unplug and re-plug the USB connector.")
+                            up.send_reboot()
+
+                            # wait for the reboot, without we might run into Serial I/O Error 5
+                            time.sleep(0.5)
+
+                            # always close the port
+                            up.close()
+                            continue
+
+                    try:
+                            # ok, we have a bootloader, try flashing it
+                            up.upload(fw)
+
+                    except RuntimeError as ex:
+                            # print the error
+                            print("\nERROR: %s" % ex.args)
+
+                    except IOError as e:
+                            up.close();
+                            continue
+
+                    finally:
+                            # always close the port
+                            up.close()
+
+                    # we could loop here if we wanted to wait for more boards...
+                    sys.exit(0)
+
+            # Delay retries to < 20 Hz to prevent spin-lock from hogging the CPU
+            time.sleep(0.05)
+
+# CTRL+C aborts the upload/spin-lock by interrupt mechanics
+except KeyboardInterrupt:
+    print("\n Upload aborted by user.")
+    sys.exit(0)


### PR DESCRIPTION
@LorenzMeier @davids5 
(Related to Issue #48)

This is the initial work that I have done on the wireless bootloading logic.

Changes:
 * BL revision increased to 6
 * PROG_MULTI protocol changed
   * Previously the protocol was PROG_MULTI/<len:1>/<data:len>/EOC, I have now changed it to PROG_MULTI/<begin_address:4>/<len:1>/<data:len>/<crc:4>/EOC
 * I need to send the address as well to say at what starting address this packet should be. This is because the response packet may not be received, in which case the same previous data packet would be sent and I need a way to ensure that that is written to the correct section of memory.
 * Added a flush to the bootloader RX buffer, so that if there is an error, (incorrect address, bad CRC, bad command) then the RX buffer is cleared for the next message that is sent.
 * Added two new failure response commands (BAD_ADDRESS and BAD_CRC). Admittedly I don't really use BAD_CRC for anything, so I could possibly remove that and just send a PROTO_INVALID response back to the uploader - please give me your input. 

I have put the px_uploader script with my changes into this PR for the moment so that you can pull and test without having to have another PR on PX4/Firmware. I will make a "sister" PR for the update of the uploader on PX4/Firmware when we are ready to merge this in.

Changes to px_uploader:
* The uploader will wait for a sync for a timeout period. If no response has been received, it will try to resend the PROG_MULTI data. 
 * If a "failed" or "invalid" response is received, it will resend the message
 * The uploader will try to program the data for up to 5 seconds. If it has not received a "successful" response, it will then timeout.

Problems:
 * The compilation is now 156 bytes too large for the standard PXIO bootloader. We will have to see what we can do to reduce the code or perhaps increase the allocated space for the PXIO bootloader.
 * Currently the response packets do not have a CRC. Therefore there is the possibility that a response packet gets mangled in the air and is received as a valid "successful" response, when it should have been an invalid response.
 * Currently only the programming of the flash message has a CRC. None of the other traffic has CRCs, so there is the potential for bad data to be received on both sides. Such as the the Serial number and chip description reporting back to the uploader. Thoughts?

I think the code definitely needs a bit more work, but I would like a bit of feedback from you guys to tell me what direction I should take this. Give it a try, first with the an FTDI cable and then perhaps with your wireless module. I have tested it with an FDTI cable simulating bit and byte drops and have also used a Laird RM024 wireless module.

What do you guys think?