### PR TITLE
Bootloader supports MindPXv2 from airmind.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ export COMMON_SRCS	 = bl.c cdcacm.c  usart.c
 #
 # Bootloaders to build
 #
-TARGETS			 = px4fmu_bl px4fmuv2_bl px4fmuv4_bl px4flow_bl px4discovery_bl px4aerocore_bl px4io_bl px4mavstation_bl
+TARGETS			 = px4fmu_bl px4fmuv2_bl px4fmuv4_bl mindpxv2_bl px4flow_bl px4discovery_bl px4aerocore_bl px4io_bl px4mavstation_bl
 
 # px4io_bl px4flow_bl
 
@@ -57,6 +57,9 @@ px4fmuv2_bl: $(MAKEFILE_LIST) $(LIBOPENCM3)
 
 px4fmuv4_bl: $(MAKEFILE_LIST) $(LIBOPENCM3)
 	make -f Makefile.f4 TARGET_HW=PX4_FMU_V4  LINKER_FILE=stm32f4.ld TARGET_FILE_NAME=$@
+
+mindpxv2_bl: $(MAKEFILE_LIST) $(LIBOPENCM3)
+	make -f Makefile.f4 TARGET_HW=MINDPX_V2 LINKER_FILE=stm32f4.ld TARGET_FILE_NAME=$@
 
 px4discovery_bl: $(MAKEFILE_LIST) $(LIBOPENCM3)
 	make -f Makefile.f4 TARGET_HW=PX4_DISCOVERY_V1  LINKER_FILE=stm32f4.ld TARGET_FILE_NAME=$@

--- a/hw_config.h
+++ b/hw_config.h
@@ -181,7 +181,7 @@
 # define INTERFACE_USB                  1
 # define INTERFACE_USART                1
 # define USBDEVICESTRING                "MindPX-V2.x BL"
-# define USBPRODUCTID                   0x0011
+# define USBPRODUCTID                   0x0030
 # define BOOT_DELAY_ADDRESS             0x000001a0
 
 # define BOARD_TYPE                     9

--- a/hw_config.h
+++ b/hw_config.h
@@ -170,6 +170,60 @@
 */
 
 /****************************************************************************
+ * TARGET_HW_MINDPX_V2
+ ****************************************************************************/
+
+#elif  defined(TARGET_HW_MINDPX_V2)
+
+# define APP_LOAD_ADDRESS               0x08004000
+# define BOOTLOADER_DELAY               5000
+# define BOARD_FMUV2
+# define INTERFACE_USB                  1
+# define INTERFACE_USART                1
+# define USBDEVICESTRING                "MindPX-V2.x BL"
+# define USBPRODUCTID                   0x0011
+# define BOOT_DELAY_ADDRESS             0x000001a0
+
+# define BOARD_TYPE                     9
+# define _FLASH_KBYTES                  (*(uint16_t *)0x1fff7a22)
+# define BOARD_FLASH_SECTORS            ((_FLASH_KBYTES == 0x400) ? 11 : 23)
+# define BOARD_FLASH_SIZE               (_FLASH_KBYTES * 1024)
+
+# define OSC_FREQ                       8
+
+# define BOARD_PIN_LED_ACTIVITY         0               // no activity LED
+# define BOARD_PIN_LED_BOOTLOADER       GPIO8
+# define BOARD_PORT_LEDS                GPIOA
+# define BOARD_CLOCK_LEDS               RCC_AHB1ENR_IOPAEN
+# define BOARD_LED_ON                   gpio_clear
+# define BOARD_LED_OFF                  gpio_set
+
+# define BOARD_USART  					USART2
+# define BOARD_USART_CLOCK_REGISTER 	RCC_APB1ENR
+# define BOARD_USART_CLOCK_BIT      	RCC_APB1ENR_USART2EN
+
+# define BOARD_PORT_USART   			GPIOD
+# define BOARD_PORT_USART_AF 			GPIO_AF7
+# define BOARD_PIN_TX     				GPIO5
+# define BOARD_PIN_RX		     		GPIO6
+# define BOARD_USART_PIN_CLOCK_REGISTER RCC_AHB1ENR
+# define BOARD_USART_PIN_CLOCK_BIT  	RCC_AHB1ENR_IOPDEN
+
+/*
+ * Uncommenting this allows to force the bootloader through
+ * a PWM output pin. As this can accidentally initialize
+ * an ESC prematurely, it is not recommended. This feature
+ * has not been used and hence defaults now to off.
+ *
+ * # define BOARD_FORCE_BL_PIN_OUT         GPIO14
+ * # define BOARD_FORCE_BL_PIN_IN          GPIO11
+ * # define BOARD_FORCE_BL_PORT            GPIOE
+ * # define BOARD_FORCE_BL_CLOCK_REGISTER  RCC_AHB1ENR
+ * # define BOARD_FORCE_BL_CLOCK_BIT       RCC_AHB1ENR_IOPEEN
+ * # define BOARD_FORCE_BL_PULL            GPIO_PUPD_PULLUP
+ */
+
+/****************************************************************************
  * TARGET_HW_PX4_FLOW_V1
  ****************************************************************************/
 


### PR DESCRIPTION
Bootloader supports MindPXv2 from airmind.

We change the usb product id to 0x0030.  If it's not accept, please help re-assign an ID.
Thanks.