### PR TITLE
STM32F467 enabled bootloader

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,10 +45,9 @@ TARGETS	= \
 	px4fmu_bl \
 	px4fmuv2_bl \
 	px4fmuv4_bl \
+	px4fmuv4pro_bl \
 	px4io_bl \
 	tapv1_bl \
-
-# px4io_bl px4flow_bl
 
 all:	$(TARGETS)
 
@@ -72,6 +71,9 @@ px4fmuv2_bl: $(MAKEFILE_LIST) $(LIBOPENCM3)
 
 px4fmuv4_bl: $(MAKEFILE_LIST) $(LIBOPENCM3)
 	make -f Makefile.f4 TARGET_HW=PX4_FMU_V4  LINKER_FILE=stm32f4.ld TARGET_FILE_NAME=$@
+
+px4fmuv4pro_bl:$(MAKEFILE_LIST) $(LIBOPENCM3)
+	make -f Makefile.f4 TARGET_HW=PX4_FMU_V4_PRO LINKER_FILE=stm32f4.ld TARGET_FILE_NAME=$@ EXTRAFLAGS=-DSTM32F469
 
 mindpxv2_bl: $(MAKEFILE_LIST) $(LIBOPENCM3)
 	make -f Makefile.f4 TARGET_HW=MINDPX_V2 LINKER_FILE=stm32f4.ld TARGET_FILE_NAME=$@

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ TARGETS	= \
 	px4fmuv4_bl \
 	px4fmuv4pro_bl \
 	px4io_bl \
+	px4iov3_bl \
 	tapv1_bl \
 
 all:	$(TARGETS)
@@ -96,6 +97,9 @@ crazyflie_bl: $(MAKEFILE_LIST) $(LIBOPENCM3)
 #
 px4io_bl: $(MAKEFILE_LIST) $(LIBOPENCM3)
 	make -f Makefile.f1 TARGET_HW=PX4_PIO_V1 LINKER_FILE=stm32f1.ld TARGET_FILE_NAME=$@
+
+px4iov3_bl: $(MAKEFILE_LIST) $(LIBOPENCM3)
+	make -f Makefile.f3 TARGET_HW=PX4_PIO_V3 LINKER_FILE=stm32f3.ld TARGET_FILE_NAME=$@
 
 tapv1_bl: $(MAKEFILE_LIST) $(LIBOPENCM3)
 	make -f Makefile.f4 TARGET_HW=TAP_V1 LINKER_FILE=stm32f4.ld TARGET_FILE_NAME=$@

--- a/Makefile.f3
+++ b/Makefile.f3
@@ -1,0 +1,38 @@
+#
+# PX4 bootloader build rules for STM32F3 targets.
+#
+
+OPENOCD		?= openocd
+
+JTAGCONFIG ?= interface/olimex-jtag-tiny.cfg
+#JTAGCONFIG ?= interface/jtagkey-tiny.cfg
+
+# 5 seconds / 5000 ms default delay
+PX4_BOOTLOADER_DELAY	?= 5000
+
+SRCS		 = $(COMMON_SRCS) main_f3.c
+
+FLAGS		+= -mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16 \
+       -DTARGET_HW_$(TARGET_HW) \
+       -DSTM32F3 \
+       -T$(LINKER_FILE) \
+		   -L$(LIBOPENCM3)/lib \
+		   -lopencm3_stm32f3 \
+        $(EXTRAFLAGS)
+
+ELF		 = $(TARGET_FILE_NAME).elf
+BINARY		 = $(TARGET_FILE_NAME).bin
+
+all:		$(ELF) $(BINARY)
+
+$(ELF):		$(SRCS) $(MAKEFILE_LIST)
+	$(CC) -o $@ $(SRCS) $(FLAGS)
+
+$(BINARY):	$(ELF)
+	$(OBJCOPY) -O binary $(ELF) $(BINARY)
+
+#upload: all flash flash-bootloader
+upload: all flash-bootloader
+
+flash-bootloader:
+	$(OPENOCD) --search ../px4_bootloader -f $(JTAGCONFIG) -f stm32f3x.cfg -c init -c "reset halt" -c "flash write_image erase $(BINARY) 0x08000000" -c "reset run" -c shutdown

--- a/cdcacm.c
+++ b/cdcacm.c
@@ -316,7 +316,7 @@ usb_cinit(void)
 	gpio_set(GPIOA, GPIO8);
 	gpio_set_mode(GPIOA, GPIO_MODE_OUTPUT_2_MHZ, GPIO_CNF_OUTPUT_PUSHPULL, GPIO8);
 
-	usbd_dev = usbd_init(&stm32f103_usb_driver, &dev, &config, usb_strings, NUM_USB_STRINGS,
+	usbd_dev = usbd_init(&st_usbfs_v1_usb_driver, &dev, &config, usb_strings, NUM_USB_STRINGS,
 			     usbd_control_buffer, sizeof(usbd_control_buffer));
 #endif
 

--- a/cdcacm.c
+++ b/cdcacm.c
@@ -43,7 +43,7 @@
 #include <libopencm3/usb/cdc.h>
 
 #include "bl.h"
-
+#if INTERFACE_USB != 0
 #define USB_CDC_REQ_GET_LINE_CODING			0x21 // Not defined in libopencm3
 
 
@@ -379,3 +379,4 @@ usb_cout(uint8_t *buf, unsigned count)
 		}
 	}
 }
+#endif

--- a/cdcacm.c
+++ b/cdcacm.c
@@ -305,7 +305,7 @@ usb_cinit(void)
 	gpio_set_af(GPIOA, GPIO_AF10, GPIO9 | GPIO11 | GPIO12);
 
 #if defined(BOARD_USB_VBUS_SENSE_DISABLED)
-	OTG_FS_GCCFG |= OTG_FS_GCCFG_NOVBUSSENS;
+	OTG_FS_GCCFG |= OTG_GCCFG_NOVBUSSENS;
 #endif
 
 	usbd_dev = usbd_init(&otgfs_usb_driver, &dev, &config, usb_strings, NUM_USB_STRINGS,

--- a/hw_config.h
+++ b/hw_config.h
@@ -420,6 +420,53 @@
 # define FLASH_SECTOR_SIZE              0x400
 
 /****************************************************************************
+ * TARGET_HW_PX4_PIO_V3
+ ****************************************************************************/
+
+#elif  defined(TARGET_HW_PX4_PIO_V3)
+
+# define APP_LOAD_ADDRESS               0x08001000
+# define APP_SIZE_MAX                   0x3f000
+# define BOOTLOADER_DELAY               200
+# define BOARD_PIO
+# define INTERFACE_USB                	0
+# define INTERFACE_USART                1
+# define USBDEVICESTRING                ""
+# define USBPRODUCTID                   -1
+
+# define OSC_FREQ                       24
+
+# define BOARD_PIN_LED_ACTIVITY         0
+# define BOARD_PIN_LED_BOOTLOADER       GPIO13
+# define BOARD_PORT_LEDS                GPIOB
+# define BOARD_CLOCK_LEDS_REGISTER      RCC_AHBENR
+# define BOARD_CLOCK_LEDS               RCC_AHBENR_IOPBEN
+# define BOARD_LED_ON                   gpio_clear
+# define BOARD_LED_OFF                  gpio_set
+
+# define BOARD_USART                    USART2
+# define BOARD_USART_CLOCK_REGISTER     RCC_APB1ENR
+# define BOARD_USART_CLOCK_BIT          RCC_APB1ENR_USART2EN
+
+# define BOARD_PORT_USART               GPIOA
+# define BOARD_PORT_USART_AF 			GPIO_AF7
+# define BOARD_PIN_TX     				GPIO2
+# define BOARD_PIN_RX		     		GPIO3
+# define BOARD_USART_PIN_CLOCK_REGISTER RCC_AHBENR
+# define BOARD_USART_PIN_CLOCK_BIT      RCC_AHBENR_IOPAEN
+
+# define BOARD_FORCE_BL_PIN             GPIO5
+# define BOARD_FORCE_BL_PORT            GPIOB
+# define BOARD_FORCE_BL_CLOCK_REGISTER  RCC_AHBENR
+# define BOARD_FORCE_BL_CLOCK_BIT       RCC_AHBENR_IOPBEN
+# define BOARD_FORCE_BL_PULL            GPIO_PUPD_NONE // depend on external pull
+# define BOARD_FORCE_BL_VALUE           BOARD_FORCE_BL_PIN
+
+# define BOARD_FLASH_SECTORS            60
+# define BOARD_TYPE                     13
+# define FLASH_SECTOR_SIZE              0x800
+
+/****************************************************************************
  * TARGET_HW_PX4_AEROCORE_V1
  ****************************************************************************/
 

--- a/hw_config.h
+++ b/hw_config.h
@@ -211,6 +211,59 @@
  * # define BOARD_FORCE_BL_CLOCK_BIT       RCC_AHB1ENR_IOPEEN
  * # define BOARD_FORCE_BL_PULL            GPIO_PUPD_PULLUP
 */
+/****************************************************************************
+ * TARGET_HW_PX4_FMU_V4_PRO
+ ****************************************************************************/
+
+#elif  defined(TARGET_HW_PX4_FMU_V4_PRO)
+
+# define APP_LOAD_ADDRESS               0x08004000
+# define BOOTLOADER_DELAY               5000
+# define BOARD_FMUV2
+# define INTERFACE_USB                  1
+# define INTERFACE_USART                1
+# define USBDEVICESTRING                "PX4 BL FMU v4.x PRO"
+# define USBPRODUCTID                   0x0013
+# define BOOT_DELAY_ADDRESS             0x000001a0
+
+# define BOARD_TYPE                     50
+# define _FLASH_KBYTES                  (*(uint16_t *)0x1fff7a22)
+# define BOARD_FLASH_SECTORS            ((_FLASH_KBYTES == 0x400) ? 11 : 23)
+# define BOARD_FLASH_SIZE               (_FLASH_KBYTES * 1024)
+
+# define OSC_FREQ                       24
+
+# define BOARD_PIN_LED_ACTIVITY         GPIO3
+# define BOARD_PIN_LED_BOOTLOADER       GPIO11|GPIO1
+# define BOARD_PORT_LEDS                GPIOB
+# define BOARD_CLOCK_LEDS               RCC_AHB1ENR_IOPBEN
+# define BOARD_LED_ON                   gpio_clear
+# define BOARD_LED_OFF                  gpio_set
+
+# define BOARD_USART  					USART2
+# define BOARD_USART_CLOCK_REGISTER 	RCC_APB1ENR
+# define BOARD_USART_CLOCK_BIT      	RCC_APB1ENR_USART2EN
+
+# define BOARD_PORT_USART   			GPIOD
+# define BOARD_PORT_USART_AF 			GPIO_AF7
+# define BOARD_PIN_TX     				GPIO5
+# define BOARD_PIN_RX		     		GPIO6
+# define BOARD_USART_PIN_CLOCK_REGISTER RCC_AHB1ENR
+# define BOARD_USART_PIN_CLOCK_BIT  	RCC_AHB1ENR_IOPDEN
+
+/*
+ * Uncommenting this allows to force the bootloader through
+ * a PWM output pin. As this can accidentally initialize
+ * an ESC prematurely, it is not recommended. This feature
+ * has not been used and hence defaults now to off.
+ *
+ * # define BOARD_FORCE_BL_PIN_OUT         GPIO14
+ * # define BOARD_FORCE_BL_PIN_IN          GPIO11
+ * # define BOARD_FORCE_BL_PORT            GPIOE
+ * # define BOARD_FORCE_BL_CLOCK_REGISTER  RCC_AHB1ENR
+ * # define BOARD_FORCE_BL_CLOCK_BIT       RCC_AHB1ENR_IOPEEN
+ * # define BOARD_FORCE_BL_PULL            GPIO_PUPD_PULLUP
+*/
 
 /****************************************************************************
  * TARGET_HW_MINDPX_V2

--- a/main_f1.c
+++ b/main_f1.c
@@ -151,19 +151,19 @@ void
 clock_deinit(void)
 {
 	/* Enable internal high-speed oscillator. */
-	rcc_osc_on(HSI);
-	rcc_wait_for_osc_ready(HSI);
+	rcc_osc_on(RCC_HSI);
+	rcc_wait_for_osc_ready(RCC_HSI);
 
 	/* Reset the RCC_CFGR register */
 	RCC_CFGR = 0x000000;
 
 	/* Stop the HSE, CSS, PLL, PLLI2S, PLLSAI */
-	rcc_osc_off(HSE);
-	rcc_osc_off(PLL);
+	rcc_osc_off(RCC_HSE);
+	rcc_osc_off(RCC_PLL);
 	rcc_css_disable();
 
 	/* Reset the HSEBYP bit */
-	rcc_osc_bypass_disable(HSE);
+	rcc_osc_bypass_disable(RCC_HSE);
 
 	/* Reset the CIR register */
 	RCC_CIR = 0x000000;

--- a/main_f3.c
+++ b/main_f3.c
@@ -1,0 +1,437 @@
+/*
+ * STM32F3 board support for the bootloader.
+ *
+ */
+#include "hw_config.h"
+
+#include <stdlib.h>
+#include <libopencm3/stm32/rcc.h>
+#include <libopencm3/stm32/gpio.h>
+#include <libopencm3/stm32/desig.h>
+#include <libopencm3/stm32/flash.h>
+#include <libopencm3/stm32/usart.h>
+#include <libopencm3/stm32/pwr.h>
+#include <libopencm3/cm3/systick.h>
+
+#include "bl.h"
+
+#define UDID_START      0x1FFFF7E8
+
+// address of MCU IDCODE
+#define DBGMCU_IDCODE		0xE0042000
+#define FLASH_BASE			(0x08000000U)
+#define BOOT_RTC_REG        MMIO32(RTC_BASE + 0x50)
+
+
+#ifdef INTERFACE_USART
+# define BOARD_INTERFACE_CONFIG		(void *)BOARD_USART
+#else
+# define BOARD_INTERFACE_CONFIG		NULL
+#endif
+const struct rcc_clock_scale _rcc_hsi_8mhz = {
+
+	.pll = RCC_CFGR_PLLMUL_PLL_IN_CLK_X16,
+	.pllsrc = RCC_CFGR_PLLSRC_HSI_DIV2,
+	.hpre = RCC_CFGR_HPRE_DIV_NONE,
+	.ppre1 = RCC_CFGR_PPRE1_DIV_2,
+	.ppre2 = RCC_CFGR_PPRE2_DIV_NONE,
+	.flash_config = FLASH_ACR_PRFTBE | FLASH_ACR_LATENCY_2WS,
+	.ahb_frequency	= 64000000,
+	.apb1_frequency = 32000000,
+	.apb2_frequency = 64000000,
+};
+
+/* board definition */
+struct boardinfo board_info = {
+	.board_type	= BOARD_TYPE,
+	.board_rev	= 0,
+	.fw_size	= APP_SIZE_MAX,
+
+	.systick_mhz	= OSC_FREQ,
+};
+
+static void board_init(void);
+
+static void
+board_init(void)
+{
+	/* initialise LEDs */
+	rcc_peripheral_enable_clock(&BOARD_CLOCK_LEDS_REGISTER, BOARD_CLOCK_LEDS);
+	gpio_mode_setup(
+		BOARD_PORT_LEDS,
+		GPIO_MODE_OUTPUT,
+		GPIO_PUPD_NONE,
+		BOARD_PIN_LED_BOOTLOADER | BOARD_PIN_LED_ACTIVITY);
+	gpio_set_output_options(
+		BOARD_PORT_LEDS,
+		GPIO_OTYPE_PP,
+		GPIO_OSPEED_2MHZ,
+		BOARD_PIN_LED_BOOTLOADER | BOARD_PIN_LED_ACTIVITY);
+	BOARD_LED_ON(
+		BOARD_PORT_LEDS,
+		BOARD_PIN_LED_BOOTLOADER | BOARD_PIN_LED_ACTIVITY);
+
+	/* if we have one, enable the force-bootloader pin */
+#ifdef BOARD_FORCE_BL_PIN
+	rcc_peripheral_enable_clock(&BOARD_FORCE_BL_CLOCK_REGISTER, BOARD_FORCE_BL_CLOCK_BIT);
+	gpio_mode_setup(BOARD_FORCE_BL_PORT,
+			GPIO_MODE_INPUT,
+			BOARD_FORCE_BL_PULL,
+			BOARD_FORCE_BL_PIN);
+#endif
+
+	/* enable the backup registers */
+	rcc_peripheral_enable_clock(&RCC_APB1ENR, RCC_APB1ENR_PWREN);
+
+#ifdef INTERFACE_USART
+	/* configure usart pins */
+	rcc_peripheral_enable_clock(&BOARD_USART_PIN_CLOCK_REGISTER, BOARD_USART_PIN_CLOCK_BIT);
+	/* Setup GPIO pins for USART transmit. */
+	gpio_mode_setup(BOARD_PORT_USART, GPIO_MODE_AF, GPIO_PUPD_PULLUP, BOARD_PIN_TX | BOARD_PIN_RX);
+	/* Setup USART TX & RX pins as alternate function. */
+	gpio_set_af(BOARD_PORT_USART, BOARD_PORT_USART_AF, BOARD_PIN_TX);
+	gpio_set_af(BOARD_PORT_USART, BOARD_PORT_USART_AF, BOARD_PIN_RX);
+
+	/* configure USART clock */
+	rcc_peripheral_enable_clock(&BOARD_USART_CLOCK_REGISTER, BOARD_USART_CLOCK_BIT);
+#endif
+#ifdef INTERFACE_I2C
+# error I2C GPIO config not handled yet
+#endif
+}
+
+void
+board_deinit(void)
+{
+	/* deinitialise LEDs */
+	gpio_mode_setup(BOARD_PORT_LEDS,
+			GPIO_MODE_INPUT,
+			GPIO_PUPD_NONE,
+			BOARD_PIN_LED_BOOTLOADER | BOARD_PIN_LED_ACTIVITY);
+
+	/* if we have one, disable the force-bootloader pin */
+#ifdef BOARD_FORCE_BL_PIN
+	gpio_mode_setup(BOARD_FORCE_BL_PORT, GPIO_MODE_INPUT, GPIO_PUPD_NONE, BOARD_FORCE_BL_PIN);
+#endif
+
+	/* disable the backup registers */
+	rcc_peripheral_disable_clock(&RCC_APB1ENR, RCC_APB1ENR_PWREN);
+
+#ifdef INTERFACE_USART
+	/* deinitialise GPIO pins for USART transmit. */
+	gpio_mode_setup(BOARD_PORT_USART, GPIO_MODE_INPUT, GPIO_PUPD_NONE, BOARD_PIN_TX | BOARD_PIN_RX);
+
+	/* disable USART peripheral clock */
+	rcc_peripheral_disable_clock(&BOARD_USART_CLOCK_REGISTER, BOARD_USART_CLOCK_BIT);
+#endif
+#ifdef INTERFACE_I2C
+# error I2C GPIO config not handled yet
+#endif
+
+	/* reset the APB2 peripheral clocks */
+	RCC_AHBENR = 0x00000014; // XXX Magic reset number from STM32F3x reference manual
+}
+
+/**
+  * @brief  Initializes the RCC clock configuration.
+  *
+  * @param  clock_setup : The clock configuration to set
+  */
+static inline void
+clock_init(void)
+{
+	rcc_clock_setup_hsi(&_rcc_hsi_8mhz);
+}
+
+/**
+  * @brief  Resets the RCC clock configuration to the default reset state.
+  * @note   The default reset state of the clock configuration is given below:
+  *            - HSI ON and used as system clock source
+  *            - HSE, PLL and PLLI2S OFF
+  *            - AHB, APB1 and APB2 prescaler set to 1.
+  *            - CSS, MCO1 and MCO2 OFF
+  *            - All interrupts disabled
+  * @note   This function doesn't modify the configuration of the
+  *            - Peripheral clocks
+  *            - LSI, LSE and RTC clocks
+  */
+void
+clock_deinit(void)
+{
+	/* Enable internal high-speed oscillator. */
+	rcc_osc_on(RCC_HSI);
+	rcc_wait_for_osc_ready(RCC_HSI);
+
+	/* Reset the RCC_CFGR register */
+	RCC_CFGR = 0x000000;
+
+	/* Stop the HSE, CSS, PLL, PLLI2S, PLLSAI */
+	rcc_osc_off(RCC_HSE);
+	rcc_osc_off(RCC_PLL);
+	rcc_css_disable();
+
+	/* Reset the HSEBYP bit */
+	rcc_osc_bypass_disable(RCC_HSE);
+
+	/* Reset the CIR register */
+	RCC_CIR = 0x000000;
+}
+
+/*---------------------------------------------------------------------------*/
+/** @brief Program a Half Word to FLASH
+
+This performs all operations necessary to program a 16 bit word to FLASH memory.
+The program error flag should be checked separately for the event that memory
+was not properly erased.
+
+Status bit polling is used to detect end of operation.
+
+@param[in] address Full address of flash half word to be programmed.
+@param[in] data half word to write
+*/
+
+void flash_program_half_word(uint32_t address, uint16_t data)
+{
+	flash_wait_for_last_operation();
+
+	FLASH_CR |= FLASH_CR_PG;
+
+	MMIO16(address) = data;
+
+	flash_wait_for_last_operation();
+
+	FLASH_CR &= ~FLASH_CR_PG;
+}
+
+/*---------------------------------------------------------------------------*/
+/** @brief Program a 32 bit Word to FLASH
+
+This performs all operations necessary to program a 32 bit word to FLASH memory.
+The program error flag should be checked separately for the event that memory
+was not properly erased.
+
+Status bit polling is used to detect end of operation.
+
+@param[in] address Full address of flash word to be programmed.
+@param[in] data word to write
+*/
+
+void flash_program_word(uint32_t address, uint32_t data)
+{
+	flash_program_half_word(address, (uint16_t)data);
+	flash_program_half_word(address + 2, (uint16_t)(data >> 16));
+}
+
+/*---------------------------------------------------------------------------*/
+/** @brief Erase a Page of FLASH
+
+This performs all operations necessary to erase a page in FLASH memory.
+The page should be checked to ensure that it was properly erased. A page must
+first be fully erased before attempting to program it.
+
+Note that the page sizes differ between devices. See the reference manual or
+the FLASH programming manual for details.
+
+@param[in] page_address Full address of flash page to be erased.
+*/
+
+void flash_erase_page(uint32_t page_address)
+{
+	flash_wait_for_last_operation();
+
+	FLASH_CR |= FLASH_CR_PER;
+	FLASH_AR = page_address;
+	FLASH_CR |= FLASH_CR_STRT;
+
+	flash_wait_for_last_operation();
+
+	FLASH_CR &= ~FLASH_CR_PER;
+}
+
+uint32_t
+flash_func_sector_size(unsigned sector)
+{
+	if (sector < BOARD_FLASH_SECTORS) {
+		return FLASH_SECTOR_SIZE;
+	}
+
+	return 0;
+}
+
+void
+flash_func_erase_sector(unsigned sector)
+{
+	if (sector < BOARD_FLASH_SECTORS) {
+		flash_erase_page(APP_LOAD_ADDRESS + (sector * FLASH_SECTOR_SIZE));
+	}
+}
+
+void
+flash_func_write_word(uint32_t address, uint32_t word)
+{
+	flash_program_word(address + APP_LOAD_ADDRESS, word);
+}
+
+uint32_t
+flash_func_read_word(uint32_t address)
+{
+	return *(uint32_t *)(address + APP_LOAD_ADDRESS);
+}
+
+uint32_t
+flash_func_read_otp(uint32_t address)
+{
+	return 0;
+}
+
+uint32_t get_mcu_id(void)
+{
+	return *(uint32_t *)DBGMCU_IDCODE;
+}
+
+// See F4 version for future enhancement for full decoding
+
+int get_mcu_desc(int max, uint8_t *revstr)
+{
+	const char none[] = "STM32F3xxx,?";
+	int i;
+
+	for (i = 0; none[i] && i < max - 1; i++) {
+		revstr[i] = none[i];
+	}
+
+	return i;
+}
+
+int check_silicon(void)
+{
+	return 0;
+}
+
+uint32_t
+flash_func_read_sn(uint32_t address)
+{
+	// read a byte out from unique chip ID area
+	// it's 12 bytes, or 3 words.
+	return *(uint32_t *)(address + UDID_START);
+}
+
+void
+led_on(unsigned led)
+{
+	switch (led) {
+	case LED_ACTIVITY:
+		BOARD_LED_ON(BOARD_PORT_LEDS, BOARD_PIN_LED_ACTIVITY);
+		break;
+
+	case LED_BOOTLOADER:
+		BOARD_LED_ON(BOARD_PORT_LEDS, BOARD_PIN_LED_BOOTLOADER);
+		break;
+	}
+}
+
+void
+led_off(unsigned led)
+{
+	switch (led) {
+	case LED_ACTIVITY:
+		BOARD_LED_OFF(BOARD_PORT_LEDS, BOARD_PIN_LED_ACTIVITY);
+		break;
+
+	case LED_BOOTLOADER:
+		BOARD_LED_OFF(BOARD_PORT_LEDS, BOARD_PIN_LED_BOOTLOADER);
+		break;
+	}
+}
+
+void
+led_toggle(unsigned led)
+{
+	switch (led) {
+	case LED_ACTIVITY:
+		gpio_toggle(BOARD_PORT_LEDS, BOARD_PIN_LED_ACTIVITY);
+		break;
+
+	case LED_BOOTLOADER:
+		gpio_toggle(BOARD_PORT_LEDS, BOARD_PIN_LED_BOOTLOADER);
+		break;
+	}
+}
+
+static bool
+should_wait(void)
+{
+	bool result = false;
+
+	PWR_CR |= PWR_CR_DBP;
+
+	if (BOOT_RTC_REG == BL_WAIT_MAGIC) {
+		result = true;
+		BOOT_RTC_REG = 0;
+	}
+
+	PWR_CR &= ~PWR_CR_DBP;
+
+	return result;
+}
+
+int
+main(void)
+{
+	unsigned timeout = 0;
+
+	/* do board-specific initialisation */
+	board_init();
+
+#if defined(INTERFACE_USART) | defined (INTERFACE_USB)
+	/* XXX sniff for a USART connection to decide whether to wait in the bootloader? */
+	timeout = BOOTLOADER_DELAY;
+#endif
+
+#ifdef INTERFACE_I2C
+# error I2C bootloader detection logic not implemented
+#endif
+
+	/* if the app left a cookie saying we should wait, then wait */
+	if (should_wait()) {
+		timeout = BOOTLOADER_DELAY;
+	}
+
+#ifdef BOARD_FORCE_BL_PIN
+
+	/* if the force-BL pin state matches the state of the pin, wait in the bootloader forever */
+	if (BOARD_FORCE_BL_VALUE == gpio_get(BOARD_FORCE_BL_PORT, BOARD_FORCE_BL_PIN)) {
+		timeout = 0xffffffff;
+	}
+
+#endif
+
+	/* look for the magic wait-in-bootloader value in backup register zero */
+
+
+	/* if we aren't expected to wait in the bootloader, try to boot immediately */
+	if (timeout == 0) {
+		/* try to boot immediately */
+		jump_to_app();
+
+		/* if we returned, there is no app; go to the bootloader and stay there */
+		timeout = 0;
+	}
+
+	/* configure the clock for bootloader activity */
+	clock_init();
+
+	/* start the interface */
+	cinit(BOARD_INTERFACE_CONFIG, USART);
+
+	while (1) {
+		/* run the bootloader, possibly coming back after the timeout */
+		bootloader(timeout);
+
+		/* look to see if we can boot the app */
+		jump_to_app();
+
+		/* boot failed; stay in the bootloader forever next time */
+		timeout = 0;
+	}
+}

--- a/main_f4.c
+++ b/main_f4.c
@@ -159,7 +159,7 @@ static void board_init(void);
 #define BOOT_RTC_REG                MMIO32(RTC_BASE + 0x50)
 
 /* standard clocking for all F4 boards */
-static const clock_scale_t clock_setup = {
+static const struct rcc_clock_scale clock_setup = {
 	.pllm = OSC_FREQ,
 	.plln = 336,
 	.pllp = 2,
@@ -472,22 +472,22 @@ void
 clock_deinit(void)
 {
 	/* Enable internal high-speed oscillator. */
-	rcc_osc_on(HSI);
-	rcc_wait_for_osc_ready(HSI);
+	rcc_osc_on(RCC_HSI);
+	rcc_wait_for_osc_ready(RCC_HSI);
 
 	/* Reset the RCC_CFGR register */
 	RCC_CFGR = 0x000000;
 
 	/* Stop the HSE, CSS, PLL, PLLI2S, PLLSAI */
-	rcc_osc_off(HSE);
-	rcc_osc_off(PLL);
+	rcc_osc_off(RCC_HSE);
+	rcc_osc_off(RCC_PLL);
 	rcc_css_disable();
 
 	/* Reset the RCC_PLLCFGR register */
 	RCC_PLLCFGR = 0x24003010; // XXX Magic reset number from STM32F4xx reference manual
 
 	/* Reset the HSEBYP bit */
-	rcc_osc_bypass_disable(HSE);
+	rcc_osc_bypass_disable(RCC_HSE);
 
 	/* Reset the CIR register */
 	RCC_CIR = 0x000000;

--- a/main_f4.c
+++ b/main_f4.c
@@ -164,6 +164,9 @@ static const struct rcc_clock_scale clock_setup = {
 	.plln = 336,
 	.pllp = 2,
 	.pllq = 7,
+#if defined(STM32F446) || defined(STM32F469)
+	.pllr = 2,
+#endif
 	.hpre = RCC_CFGR_HPRE_DIV_NONE,
 	.ppre1 = RCC_CFGR_PPRE_DIV_4,
 	.ppre2 = RCC_CFGR_PPRE_DIV_2,

--- a/stm32f3.ld
+++ b/stm32f3.ld
@@ -1,0 +1,110 @@
+/************************************************************************
+ *
+ *   Copyright (c) 2012-2014 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2010 libopencm3 project (Uwe Hermann, Stephen Caudle)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * LICENSE NOTE FOR EXTERNAL LIBOPENCM3 LIBRARY:
+ *
+ *   The PX4 development team considers libopencm3 to be
+ *   still GPL, not LGPL licensed, as it is unclear if
+ *   each and every author agreed to the LGPS -> GPL change.
+ *
+ ***********************************************************************/
+
+/**
+ * @file stm32f4.ld
+ *
+ * Linker script for ST STM32F3 bootloader (use first 8K of flash, all 48K RAM).
+ *
+ * @author Uwe Hermann <uwe@hermann-uwe.de>
+ * @author Stephen Caudle <scaudle@doceme.com>
+ */
+
+/* Define memory regions. */
+MEMORY
+{
+	rom (rx)  : ORIGIN = 0x08000000, LENGTH = 8K
+	ram (rwx) : ORIGIN = 0x20000000, LENGTH = 48K
+}
+
+/* Enforce emmission of the vector table. */
+EXTERN (vector_table)
+
+/* Define sections. */
+SECTIONS
+{
+        . = ORIGIN(rom);
+
+        .text : {
+                *(.vectors)     /* Vector table */
+                *(.text*)       /* Program code */
+                . = ALIGN(4);
+                *(.rodata*)     /* Read-only data */
+                . = ALIGN(4);
+                _etext = .;
+        } >rom
+
+	/* C++ Static constructors/destructors, also used for __attribute__
+	 * ((constructor)) and the likes */
+	.preinit_array : {
+		. = ALIGN(4);
+		__preinit_array_start = .;
+		KEEP (*(.preinit_array))
+		__preinit_array_end = .;
+	} >rom
+	.init_array : {
+		. = ALIGN(4);
+		__init_array_start = .;
+		KEEP (*(SORT(.init_array.*)))
+		KEEP (*(.init_array))
+		__init_array_end = .;
+	} >rom
+	.fini_array : {
+		. = ALIGN(4);
+		__fini_array_start = .;
+		KEEP (*(.fini_array))
+		KEEP (*(SORT(.fini_array.*)))
+		__fini_array_end = .;
+	} >rom
+
+        . = ORIGIN(ram);
+
+        .data : AT(_etext) {
+                _data = .;
+                *(.data*)       /* Read-write initialized data */
+                . = ALIGN(4);
+                _edata = .;
+        } >ram
+	_data_loadaddr = LOADADDR(.data);
+
+        .bss : {
+                *(.bss*)        /* Read-write zero initialized data */
+                *(COMMON)
+                . = ALIGN(4);
+                _ebss = .;
+        } >ram AT >rom
+
+        /*
+         * The .eh_frame section appears to be used for C++ exception handling.
+         * You may need to fix this if you're using C++.
+         */
+        /DISCARD/ : { *(.eh_frame) }
+
+        . = ALIGN(4);
+        end = .;
+}
+
+PROVIDE(_stack = 0x20002000);

--- a/stm32f3x.cfg
+++ b/stm32f3x.cfg
@@ -1,0 +1,64 @@
+# script for stm32f3xxx
+
+if { [info exists CHIPNAME] } {
+   set  _CHIPNAME $CHIPNAME
+} else {
+   set  _CHIPNAME stm32f3xxx
+}
+
+if { [info exists ENDIAN] } {
+   set  _ENDIAN $ENDIAN
+} else {
+   set  _ENDIAN little
+}
+
+# Work-area is a space in RAM used for flash programming
+# By default use 64kB
+if { [info exists WORKAREASIZE] } {
+   set  _WORKAREASIZE $WORKAREASIZE
+} else {
+   set  _WORKAREASIZE 0x10000
+}
+
+# JTAG speed should be <= F_CPU/6. F_CPU after reset is 8MHz, so use F_JTAG = 1MHz
+#
+# Since we may be running of an RC oscilator, we crank down the speed a
+# bit more to be on the safe side. Perhaps superstition, but if are
+# running off a crystal, we can run closer to the limit. Note
+# that there can be a pretty wide band where things are more or less stable.
+adapter_khz 4000
+
+adapter_nsrst_delay 100
+jtag_ntrst_delay 100
+
+#jtag scan chain
+if { [info exists CPUTAPID ] } {
+   set _CPUTAPID $CPUTAPID
+} else {
+  # See STM Document RM0033
+  # Section 32.6.3 - corresponds to Cortex-M3 r2p0
+   set _CPUTAPID 0x4ba00477
+}
+jtag newtap $_CHIPNAME cpu -irlen 4 -ircapture 0x1 -irmask 0xf -expected-id $_CPUTAPID
+
+if { [info exists BSTAPID ] } {
+   set _BSTAPID $BSTAPID
+} else {
+  # See STM Document RM0033
+  # Section 32.6.2
+  # 
+  set _BSTAPID 0x06413041
+}
+jtag newtap $_CHIPNAME bs -irlen 5 -expected-id $_BSTAPID
+
+set _TARGETNAME $_CHIPNAME.cpu
+target create $_TARGETNAME cortex_m3 -endian $_ENDIAN -chain-position $_TARGETNAME -rtos auto
+
+$_TARGETNAME configure -work-area-phys 0x20000000 -work-area-size $_WORKAREASIZE -work-area-backup 0
+
+set _FLASHNAME $_CHIPNAME.flash
+flash bank $_FLASHNAME stm32f3x 0 0 0 0 $_TARGETNAME
+
+# if srst is not fitted use SYSRESETREQ to
+# perform a soft reset
+cortex_m3 reset_config sysresetreq

--- a/usart.c
+++ b/usart.c
@@ -35,6 +35,9 @@
 
 #include <libopencm3/stm32/usart.h>
 
+#if !defined(USART_SR)
+#define USART_SR USART_ISR
+#endif
 #include "bl.h"
 #include "uart.h"
 


### PR DESCRIPTION
This adds PX4 FMU V4 PRO and PX4 IO V3 bootloaders. 

Currently I am waiting on libopencm3 ( @karlp ) to merge PX4 contributions to their upstream for the USB and RCC of the STM32F469 and STM32F446.
- [x]  Need PX4 contributions upstream-ed to libopencm3 
    - Support for the PLL was incorporated upstream   
    - A work around has been added fir the USB driver issues,
- [ ]  Need to test Safety Switch BL activation and LED Safety Switch indication (waiting on cables from @pkocmoud  - Defered
- [ x] Validate RTC wait for BL 
  - tested with a forced load of V2 FW
- [ ] need PX4/Firmware for PX4 IO V - defered
