### PR TITLE
Added AUAV X2.1 Bootloader

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,18 @@ export COMMON_SRCS	 = bl.c cdcacm.c  usart.c
 #
 # Bootloaders to build
 #
-TARGETS			 = px4fmu_bl px4fmuv2_bl px4fmuv4_bl mindpxv2_bl px4flow_bl px4discovery_bl px4aerocore_bl px4io_bl tapv1_bl crazyflie_bl
+TARGETS	= \
+	auavx2v1_bl \
+	crazyflie_bl \
+	mindpxv2_bl \
+	px4aerocore_bl \
+	px4discovery_bl \
+	px4flow_bl \
+	px4fmu_bl \
+	px4fmuv2_bl \
+	px4fmuv4_bl \
+	px4io_bl \
+	tapv1_bl \
 
 # px4io_bl px4flow_bl
 
@@ -49,6 +60,9 @@ clean:
 #
 # Specific bootloader targets.
 #
+
+auavx2v1_bl: $(MAKEFILE_LIST) $(LIBOPENCM3)
+	make -f Makefile.f4 TARGET_HW=AUAV_X2V1  LINKER_FILE=stm32f4.ld TARGET_FILE_NAME=$@
 
 px4fmu_bl: $(MAKEFILE_LIST) $(LIBOPENCM3)
 	make -f Makefile.f4 TARGET_HW=PX4_FMU_V1 LINKER_FILE=stm32f4.ld TARGET_FILE_NAME=$@
@@ -83,6 +97,7 @@ px4io_bl: $(MAKEFILE_LIST) $(LIBOPENCM3)
 
 tapv1_bl: $(MAKEFILE_LIST) $(LIBOPENCM3)
 	make -f Makefile.f4 TARGET_HW=TAP_V1 LINKER_FILE=stm32f4.ld TARGET_FILE_NAME=$@
+
 
 #
 # Binary management

--- a/hw_config.h
+++ b/hw_config.h
@@ -9,10 +9,16 @@
 #define HW_CONFIG_H_
 
 /****************************************************************************
- * TARGET_HW_PX4_FMU_V1
+ * 10-8--2016:
+ *  To simplify the ripple effect on the tools, we will be using
+ *  /dev/serial/by-id/*PX4* to locate PX4 devices. Therefore
+ *  moving forward all Bootloaders must contain the prefix "PX4 BL "
+ *  in the USBDEVICESTRING
+ *  This Change will be made in an upcoming BL release
  ****************************************************************************/
 /*
  * Define usage to configure a bootloader
+ *
  *
  * Constant                example          Usage
  * APP_LOAD_ADDRESS     0x08004000            - The address in Linker Script, where the app fw is org-ed
@@ -474,6 +480,62 @@
 # define BOARD_USB_VBUS_SENSE_DISABLED
 
 # define USBMFGSTRING                   "Bitcraze AB"
+
+/****************************************************************************
+ * TARGET_HW_AUAV_X2V1
+ ****************************************************************************/
+
+#elif  defined(TARGET_HW_AUAV_X2V1)
+
+# define APP_LOAD_ADDRESS               0x08004000
+# define BOOTLOADER_DELAY               5000
+# define BOARD_FMUV2
+# define INTERFACE_USB                  1
+# define INTERFACE_USART                1
+# define USBDEVICESTRING                "PX4 BL AUAV X2.1"
+# define USBPRODUCTID                   0x0021
+# define BOOT_DELAY_ADDRESS             0x000001a0
+
+# define BOARD_TYPE                     33
+# define _FLASH_KBYTES                  (*(uint16_t *)0x1fff7a22)
+# define BOARD_FLASH_SECTORS            ((_FLASH_KBYTES == 0x400) ? 11 : 23)
+# define BOARD_FLASH_SIZE               (_FLASH_KBYTES * 1024)
+
+# define OSC_FREQ                       24
+
+# define BOARD_PIN_LED_ACTIVITY         0               // no activity LED
+# define BOARD_PIN_LED_BOOTLOADER       GPIO12
+# define BOARD_PORT_LEDS                GPIOE
+# define BOARD_CLOCK_LEDS               RCC_AHB1ENR_IOPEEN
+# define BOARD_LED_ON                   gpio_clear
+# define BOARD_LED_OFF                  gpio_set
+
+# define BOARD_USART  					USART2
+# define BOARD_USART_CLOCK_REGISTER 	RCC_APB1ENR
+# define BOARD_USART_CLOCK_BIT      	RCC_APB1ENR_USART2EN
+
+# define BOARD_PORT_USART   			GPIOD
+# define BOARD_PORT_USART_AF 			GPIO_AF7
+# define BOARD_PIN_TX     				GPIO5
+# define BOARD_PIN_RX		     		GPIO6
+# define BOARD_USART_PIN_CLOCK_REGISTER RCC_AHB1ENR
+# define BOARD_USART_PIN_CLOCK_BIT  	RCC_AHB1ENR_IOPDEN
+
+/*
+ * Uncommenting this allows to force the bootloader through
+ * a PWM output pin. As this can accidentally initialize
+ * an ESC prematurely, it is not recommended. This feature
+ * has not been used and hence defaults now to off.
+ *
+ * # define BOARD_FORCE_BL_PIN_OUT         GPIO14
+ * # define BOARD_FORCE_BL_PIN_IN          GPIO11
+ * # define BOARD_FORCE_BL_PORT            GPIOE
+ * # define BOARD_FORCE_BL_CLOCK_REGISTER  RCC_AHB1ENR
+ * # define BOARD_FORCE_BL_CLOCK_BIT       RCC_AHB1ENR_IOPEEN
+ * # define BOARD_FORCE_BL_PULL            GPIO_PUPD_PULLUP
+ */
+
+# define USBMFGSTRING                   "AUAV"
 
 #else
 # error Undefined Target Hardware

--- a/hw_config.h
+++ b/hw_config.h
@@ -11,7 +11,7 @@
 /****************************************************************************
  * 10-8--2016:
  *  To simplify the ripple effect on the tools, we will be using
- *  /dev/serial/by-id/*PX4* to locate PX4 devices. Therefore
+ *  /dev/serial/by-id/<asterisk>PX4<asterisk> to locate PX4 devices. Therefore
  *  moving forward all Bootloaders must contain the prefix "PX4 BL "
  *  in the USBDEVICESTRING
  *  This Change will be made in an upcoming BL release


### PR DESCRIPTION
@LorenzMeier 

Added the AUAV X2.1 Bootloader and a note about using the
required "PX4 BL " in the USBDEVICESTRING.
This requierment is to simplify the ripple effect on the tools,
we will be using /dev/serial/by-id/_PX4_ to locate PX4 devices.
Therefore moving forward all Bootloaders must contain the prefix
"PX4 BL " in the USBDEVICESTRING
