### PR TITLE
Master vbus conf 

### DIFF
--- a/cdcacm.c
+++ b/cdcacm.c
@@ -309,10 +309,10 @@ usb_cinit(void)
 	systick_interrupt_disable();
 	systick_counter_disable(); // Stop the timer
 #endif
-	/* Configure to use the Alternate IO Functions USB DP,DM and VBUS */
+	/* Configure to use the Alternate IO Functions USB DP,DM */
 
-	gpio_mode_setup(GPIOA, GPIO_MODE_AF, GPIO_PUPD_NONE, GPIO9 | GPIO11 | GPIO12);
-	gpio_set_af(GPIOA, GPIO_AF10, GPIO9 | GPIO11 | GPIO12);
+	gpio_mode_setup(GPIOA, GPIO_MODE_AF, GPIO_PUPD_NONE, GPIO11 | GPIO12);
+	gpio_set_af(GPIOA, GPIO_AF10, GPIO11 | GPIO12);
 
 #if defined(BOARD_USB_VBUS_SENSE_DISABLED)
 	OTG_FS_GCCFG |= OTG_GCCFG_NOVBUSSENS;
@@ -361,7 +361,7 @@ usb_cfini(void)
 
 #if defined(STM32F4)
 	/* Reset the USB pins to being floating inputs */
-	gpio_mode_setup(GPIOA, GPIO_MODE_INPUT, GPIO_PUPD_NONE, GPIO9 | GPIO11 | GPIO12);
+	gpio_mode_setup(GPIOA, GPIO_MODE_INPUT, GPIO_PUPD_NONE, GPIO11 | GPIO12);
 
 	/* Disable the OTGFS peripheral clock */
 	rcc_peripheral_disable_clock(&RCC_AHB2ENR, RCC_AHB2ENR_OTGFSEN);

--- a/main_f4.c
+++ b/main_f4.c
@@ -346,9 +346,9 @@ board_init(void)
 #endif
 
 #if INTERFACE_USB
-	/* enable GPIO9 with a pulldown to sniff VBUS */
+
+	/* enable Port A GPIO9 to sample VBUS */
 	rcc_peripheral_enable_clock(&RCC_AHB1ENR, RCC_AHB1ENR_IOPAEN);
-	gpio_mode_setup(GPIOA, GPIO_MODE_INPUT, GPIO_PUPD_PULLDOWN, GPIO9);
 #endif
 
 #if INTERFACE_USART
@@ -402,10 +402,6 @@ board_init(void)
 void
 board_deinit(void)
 {
-#if INTERFACE_USB
-	/* deinitialise GPIO9 (used to sniff VBUS) */
-	gpio_mode_setup(GPIOA, GPIO_MODE_INPUT, GPIO_PUPD_NONE, GPIO9);
-#endif
 
 #if INTERFACE_USART
 	/* deinitialise GPIO pins for USART transmit. */


### PR DESCRIPTION
@LorenzMeier 

Adresses https://github.com/PX4/Bootloader/issues/30

I can go either way on 066213f - The data sheet seems to suggest that PA9 has a 1.1K Pull down. The question is whether it is enabled when the pin is left floating. I think we should discuss this.

The second commit seems like it makes good sense.
