### PR TITLE
cdcacm.c: fix busy loop if no USB is connected

### DIFF
--- a/cdcacm.c
+++ b/cdcacm.c
@@ -394,6 +394,12 @@ usb_cout(uint8_t *buf, unsigned count)
 
 			sent = usbd_ep_write_packet(usbd_dev, 0x82, buf, len);
 
+			if (sent == 0) {
+				// usbd_ep_write_packet() returns 0 if it failed in which
+				// case we do not want to busy loop but give up.
+				return;
+			}
+
 			count -= sent;
 			buf += sent;
 		}

--- a/cdcacm.c
+++ b/cdcacm.c
@@ -388,20 +388,28 @@ void
 usb_cout(uint8_t *buf, unsigned count)
 {
 	if (usbd_dev) {
+
 		while (count) {
 			unsigned len = (count > 64) ? 64 : count;
-			unsigned sent;
 
-			sent = usbd_ep_write_packet(usbd_dev, 0x82, buf, len);
+			unsigned retries = 0;
+			while (true) {
 
-			if (sent == 0) {
+				unsigned sent = usbd_ep_write_packet(usbd_dev, 0x82, buf, len);
 				// usbd_ep_write_packet() returns 0 if it failed in which
 				// case we do not want to busy loop but give up.
-				return;
+				if (sent == 0) {
+					// Still, it seems that we need to retry a couple of times.
+					if (retries++ == 1000) {
+						// Give up
+						return;
+					}
+				} else {
+					count -= sent;
+					buf += sent;
+					break;
+				}
 			}
-
-			count -= sent;
-			buf += sent;
 		}
 	}
 }


### PR DESCRIPTION
The bootloader was able to get into a failure state/busy loop in case
that nothing is connected over USB but receives garbage on the USART.

When it tries to (n)acknowledge the garbage on USB and USART, it gets
stuck on USB because usbd_ep_write_packet returns 0 and it can never
leave the while loop.

@LorenzMeier or @davids5 please review.