### PR TITLE
A Bootloader should never speak until spoken to

### DIFF
--- a/bl.c
+++ b/bl.c
@@ -178,19 +178,18 @@ inline void cout(uint8_t *buf, unsigned len)
 {
 #if INTERFACE_USB
 
-	if (bl_type == NONE || bl_type == USB) {
+	if (bl_type == USB) {
 		usb_cout(buf, len);
 	}
 
 #endif
 #if INTERFACE_USART
 
-	if (bl_type == NONE || bl_type == USART) {
+	if (bl_type == USART) {
 		uart_cout(buf, len);
 	}
 
 #endif
-
 }
 
 


### PR DESCRIPTION
This fixes the issue where usb_cout got stuck because it was not
connected when trying to nack something that arrived on USART.

This is a better fix than #70 according to @davids5.