### PR TITLE
Build Time  ability to disable Serial Break detection from entering BL

### DIFF
--- a/hw_config.h
+++ b/hw_config.h
@@ -52,6 +52,7 @@
  *                                                                        BOARD_FLASH_SIZE to determine the size of the App FW
  *                                                                        and hence the address space of FLASH to erase and program.
  * USBMFGSTRING            "PX4 AP"            - Optional USB MFG string (default is '3D Robotics' if not defined.)
+ * SERIAL_BREAK_DETECT_DISABLED                -  Optional prevent break selection on Serial port from entering or staying in BL
  *
  * * Other defines are somewhat self explanatory.
  */
@@ -602,6 +603,7 @@
 # undef  BOARD_POWER_PIN_RELEASE		/* Leave pin enabling Power - un comment to release (disable power)*/
 # define USBMFGSTRING                   "The Autopilot"
 # define USB_FORCE_DISCONNECT			1
+#define  SERIAL_BREAK_DETECT_DISABLED   1
 
 /****************************************************************************
  * TARGET_HW_CRAZYFLIE

--- a/main_f4.c
+++ b/main_f4.c
@@ -266,6 +266,7 @@ board_test_force_pin()
 static bool
 board_test_usart_receiving_break()
 {
+#if !defined(SERIAL_BREAK_DETECT_DISABLED)
 	/* (re)start the SysTick timer system */
 	systick_interrupt_disable(); // Kill the interrupt if it is still active
 	systick_counter_disable(); // Stop the timer
@@ -319,6 +320,7 @@ board_test_usart_receiving_break()
 	if (cnt_consecutive_low >= 18) {
 		return true;
 	}
+#endif // !defined(SERIAL_BREAK_DETECT_DISABLED)
 
 	return false;
 }

--- a/main_f7.c
+++ b/main_f7.c
@@ -240,6 +240,7 @@ board_test_force_pin()
 static bool
 board_test_usart_receiving_break()
 {
+#if !defined(SERIAL_BREAK_DETECT_DISABLED)
 	/* (re)start the SysTick timer system */
 	systick_interrupt_disable(); // Kill the interrupt if it is still active
 	systick_counter_disable(); // Stop the timer
@@ -293,6 +294,7 @@ board_test_usart_receiving_break()
 	if (cnt_consecutive_low >= 18) {
 		return true;
 	}
+#endif // !defined(SERIAL_BREAK_DETECT_DISABLED)
 
 	return false;
 }


### PR DESCRIPTION
This adds a build time option the ability to disable Serial Break detection from entering and staying in bootloader.