### PR TITLE
Moved buad rate setting to hw_config and allow override

### DIFF
--- a/hw_config.h
+++ b/hw_config.h
@@ -754,4 +754,10 @@
 #  define BOARD_FIRST_FLASH_SECTOR_TO_ERASE 0
 #endif
 
+#if defined(OVERRIDE_USART_BAUDRATE)
+#  define USART_BAUDRATE OVERRIDE_USART_BAUDRATE
+#else
+#  define USART_BAUDRATE 115200
+#endif
+
 #endif /* HW_CONFIG_H_ */

--- a/usart.c
+++ b/usart.c
@@ -52,7 +52,7 @@ uart_cinit(void *config)
 
 	/* do usart setup */
 	//USART_CR1(usart) |= (1 << 15);	/* because libopencm3 doesn't know the OVER8 bit */
-	usart_set_baudrate(usart, 115200);
+	usart_set_baudrate(usart, USART_BAUDRATE);
 	usart_set_databits(usart, 8);
 	usart_set_stopbits(usart, USART_STOPBITS_1);
 	usart_set_mode(usart, USART_MODE_TX_RX);


### PR DESCRIPTION
  The default is to used the USART_BAUDRATE of 115200 but  a board can override it by setting OVERRIDE_USART_BAUDRATE