### PR TITLE
TARGET_HW_PX4_PIO_V3 (inactive) wrong sector count

### DIFF
--- a/hw_config.h
+++ b/hw_config.h
@@ -516,7 +516,7 @@
 # define BOARD_FORCE_BL_PULL            GPIO_PUPD_NONE // depend on external pull
 # define BOARD_FORCE_BL_VALUE           BOARD_FORCE_BL_PIN
 
-# define BOARD_FLASH_SECTORS            60
+# define BOARD_FLASH_SECTORS            (128-4) /* application #sec - bootloader - sec */
 # define BOARD_TYPE                     13
 # define FLASH_SECTOR_SIZE              0x800
 


### PR DESCRIPTION
Remove the bootloader # of Sectors from total Sectors as the EA is calulated as APP_LOAD_ADDRESS + (sector * FLASH_SECTOR_SIZE)
and tested as sector < BOARD_FLASH_SECTORS.
Therefore sector 0 is the first sector of the Application and FLASH_SECTOR_SIZE = the last sector sector number of the  application + 1