### PR TITLE
WIP: Clock deinit was not selecting HSI as clock source for SYSCLK - might not be necessary

### DIFF
--- a/main_f1.c
+++ b/main_f1.c
@@ -154,6 +154,17 @@ clock_deinit(void)
 	rcc_osc_on(RCC_HSI);
 	rcc_wait_for_osc_ready(RCC_HSI);
 
+	/* Select HSI as SYSCLK source. */
+	rcc_set_sysclk_source(RCC_CFGR_SW_SYSCLKSEL_HSICLK);
+
+	/* Wait for HSI clock to be selected. */
+	/* The libopencm3 library currently doesn't have a rcc_wait_for_sysclk_status
+	   function for the f1s like what they have for the f4s. If/when this function has
+	   been added to the library, the function should be called here to ensure that the
+	   HSI is being used for the SYSCLK.
+	*/
+
+
 	/* Reset the RCC_CFGR register */
 	RCC_CFGR = 0x000000;
 

--- a/main_f3.c
+++ b/main_f3.c
@@ -162,6 +162,12 @@ clock_deinit(void)
 	rcc_osc_on(RCC_HSI);
 	rcc_wait_for_osc_ready(RCC_HSI);
 
+	/* Select HSI as SYSCLK source. */
+	rcc_set_sysclk_source(RCC_CFGR_SW_HSI);
+
+	/* Wait for HSI clock to be selected. */
+	rcc_wait_for_sysclk_status(RCC_HSI);
+
 	/* Reset the RCC_CFGR register */
 	RCC_CFGR = 0x000000;
 

--- a/main_f4.c
+++ b/main_f4.c
@@ -476,6 +476,12 @@ clock_deinit(void)
 	rcc_osc_on(RCC_HSI);
 	rcc_wait_for_osc_ready(RCC_HSI);
 
+	/* Select HSI as SYSCLK source. */
+	rcc_set_sysclk_source(RCC_CFGR_SW_HSI);
+
+	/* Wait for HSI clock to be selected. */
+	rcc_wait_for_sysclk_status(RCC_HSI);
+
 	/* Reset the RCC_CFGR register */
 	RCC_CFGR = 0x000000;
 

--- a/main_f7.c
+++ b/main_f7.c
@@ -443,6 +443,12 @@ clock_deinit(void)
 	rcc_osc_on(RCC_HSI);
 	rcc_wait_for_osc_ready(RCC_HSI);
 
+	/* Select HSI as SYSCLK source. */
+	rcc_set_sysclk_source(RCC_CFGR_SW_HSI);
+
+	/* Wait for HSI clock to be selected. */
+	rcc_wait_for_sysclk_status(RCC_HSI);
+
 	/* Reset the RCC_CFGR register */
 	RCC_CFGR = 0x000000;
 


### PR DESCRIPTION
When resetting the clock before jumping to the main application, the HSI was being started but not being selected as the SYSCLK source (which is the default after reset). This didn't cause a problem if you were using the same clock source in the main application as the bootloader, but if you were using the HSE in the bootloader and then the HSE in the main application (because you were testing out using the internal clock as you clock source) this caused issues.

Please test on the Px4FMUv2 (I don't have one) - I could only test on Px4FMUv1 and my own custom board.