### PR TITLE
Adds auto dependencies for make

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .project
 .settings
 *.o
+*.d
 *.elf
 *.bin
 Bootloader.zip

--- a/Makefile
+++ b/Makefile
@@ -57,8 +57,8 @@ all:	$(TARGETS) sizes
 
 clean:
 	cd libopencm3 && make --no-print-directory clean && cd ..
-	rm -f *.elf *.bin
-	rm -rf build_*
+	rm -f *.elf *.bin # Remove any elf or bin files contained directly in the Bootloader directory
+	rm -rf build_* # Remove build directories
 
 #
 # Specific bootloader targets.

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ all:	$(TARGETS) sizes
 
 clean:
 	cd libopencm3 && make --no-print-directory clean && cd ..
-	rm -r build_*
+	rm -rf build_*
 
 #
 # Specific bootloader targets.

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 #
 export BL_BASE		?= $(wildcard .)
 export LIBOPENCM3	?= $(wildcard libopencm3)
-
+MKFLAGS=--no-print-directory
 #
 # Tools
 #
@@ -64,53 +64,53 @@ clean:
 #
 
 auavx2v1_bl: $(MAKEFILE_LIST) $(LIBOPENCM3)
-	make -f Makefile.f4 TARGET_HW=AUAV_X2V1  LINKER_FILE=stm32f4.ld TARGET_FILE_NAME=$@
+	${MAKE} ${MKFLAGS} -f  Makefile.f4 TARGET_HW=AUAV_X2V1  LINKER_FILE=stm32f4.ld TARGET_FILE_NAME=$@
 
 px4fmu_bl: $(MAKEFILE_LIST) $(LIBOPENCM3)
-	make -f Makefile.f4 TARGET_HW=PX4_FMU_V1 LINKER_FILE=stm32f4.ld TARGET_FILE_NAME=$@
+	${MAKE} ${MKFLAGS} -f  Makefile.f4 TARGET_HW=PX4_FMU_V1 LINKER_FILE=stm32f4.ld TARGET_FILE_NAME=$@
 
 px4fmuv2_bl: $(MAKEFILE_LIST) $(LIBOPENCM3)
-	make -f Makefile.f4 TARGET_HW=PX4_FMU_V2  LINKER_FILE=stm32f4.ld TARGET_FILE_NAME=$@
+	${MAKE} ${MKFLAGS} -f  Makefile.f4 TARGET_HW=PX4_FMU_V2  LINKER_FILE=stm32f4.ld TARGET_FILE_NAME=$@
 
 px4fmuv4_bl: $(MAKEFILE_LIST) $(LIBOPENCM3)
-	make -f Makefile.f4 TARGET_HW=PX4_FMU_V4  LINKER_FILE=stm32f4.ld TARGET_FILE_NAME=$@
+	${MAKE} ${MKFLAGS} -f  Makefile.f4 TARGET_HW=PX4_FMU_V4  LINKER_FILE=stm32f4.ld TARGET_FILE_NAME=$@
 
 px4fmuv4pro_bl:$(MAKEFILE_LIST) $(LIBOPENCM3)
-	make -f Makefile.f4 TARGET_HW=PX4_FMU_V4_PRO LINKER_FILE=stm32f4.ld TARGET_FILE_NAME=$@ EXTRAFLAGS=-DSTM32F469
+	${MAKE} ${MKFLAGS} -f  Makefile.f4 TARGET_HW=PX4_FMU_V4_PRO LINKER_FILE=stm32f4.ld TARGET_FILE_NAME=$@ EXTRAFLAGS=-DSTM32F469
 
 px4fmuv5_bl:$(MAKEFILE_LIST) $(LIBOPENCM3)
-	make -f Makefile.f7 TARGET_HW=PX4_FMU_V5 LINKER_FILE=stm32f7.ld TARGET_FILE_NAME=$@
+	${MAKE} ${MKFLAGS} -f  Makefile.f7 TARGET_HW=PX4_FMU_V5 LINKER_FILE=stm32f7.ld TARGET_FILE_NAME=$@
 
 mindpxv2_bl: $(MAKEFILE_LIST) $(LIBOPENCM3)
-	make -f Makefile.f4 TARGET_HW=MINDPX_V2 LINKER_FILE=stm32f4.ld TARGET_FILE_NAME=$@
+	${MAKE} ${MKFLAGS} -f  Makefile.f4 TARGET_HW=MINDPX_V2 LINKER_FILE=stm32f4.ld TARGET_FILE_NAME=$@
 
 px4discovery_bl: $(MAKEFILE_LIST) $(LIBOPENCM3)
-	make -f Makefile.f4 TARGET_HW=PX4_DISCOVERY_V1  LINKER_FILE=stm32f4.ld TARGET_FILE_NAME=$@
+	${MAKE} ${MKFLAGS} -f  Makefile.f4 TARGET_HW=PX4_DISCOVERY_V1  LINKER_FILE=stm32f4.ld TARGET_FILE_NAME=$@
 
 px4flow_bl: $(MAKEFILE_LIST) $(LIBOPENCM3)
-	make -f Makefile.f4 TARGET_HW=PX4_FLOW_V1  LINKER_FILE=stm32f4.ld TARGET_FILE_NAME=$@
+	${MAKE} ${MKFLAGS} -f  Makefile.f4 TARGET_HW=PX4_FLOW_V1  LINKER_FILE=stm32f4.ld TARGET_FILE_NAME=$@
 
 px4aerocore_bl: $(MAKEFILE_LIST) $(LIBOPENCM3)
-	make -f Makefile.f4 TARGET_HW=PX4_AEROCORE_V1 LINKER_FILE=stm32f4.ld TARGET_FILE_NAME=$@
+	${MAKE} ${MKFLAGS} -f  Makefile.f4 TARGET_HW=PX4_AEROCORE_V1 LINKER_FILE=stm32f4.ld TARGET_FILE_NAME=$@
 
 crazyflie_bl: $(MAKEFILE_LIST) $(LIBOPENCM3)
-	make -f Makefile.f4 TARGET_HW=CRAZYFLIE LINKER_FILE=stm32f4.ld TARGET_FILE_NAME=$@
+	${MAKE} ${MKFLAGS} -f  Makefile.f4 TARGET_HW=CRAZYFLIE LINKER_FILE=stm32f4.ld TARGET_FILE_NAME=$@
 
 # Default bootloader delay is *very* short, just long enough to catch
 # the board for recovery but not so long as to make restarting after a
 # brownout problematic.
 #
 px4io_bl: $(MAKEFILE_LIST) $(LIBOPENCM3)
-	make -f Makefile.f1 TARGET_HW=PX4_PIO_V1 LINKER_FILE=stm32f1.ld TARGET_FILE_NAME=$@
+	${MAKE} ${MKFLAGS} -f  Makefile.f1 TARGET_HW=PX4_PIO_V1 LINKER_FILE=stm32f1.ld TARGET_FILE_NAME=$@
 
 px4iov3_bl: $(MAKEFILE_LIST) $(LIBOPENCM3)
-	make -f Makefile.f3 TARGET_HW=PX4_PIO_V3 LINKER_FILE=stm32f3.ld TARGET_FILE_NAME=$@
+	${MAKE} ${MKFLAGS} -f  Makefile.f3 TARGET_HW=PX4_PIO_V3 LINKER_FILE=stm32f3.ld TARGET_FILE_NAME=$@
 
 tapv1_bl: $(MAKEFILE_LIST) $(LIBOPENCM3)
-	make -f Makefile.f4 TARGET_HW=TAP_V1 LINKER_FILE=stm32f4.ld TARGET_FILE_NAME=$@
+	${MAKE} ${MKFLAGS} -f  Makefile.f4 TARGET_HW=TAP_V1 LINKER_FILE=stm32f4.ld TARGET_FILE_NAME=$@
 
 aerofcv1_bl: $(MAKEFILE_LIST) $(LIBOPENCM3)
-	make -f Makefile.f4 TARGET_HW=AEROFC_V1 LINKER_FILE=stm32f4.ld TARGET_FILE_NAME=$@
+	${MAKE} ${MKFLAGS} -f  Makefile.f4 TARGET_HW=AEROFC_V1 LINKER_FILE=stm32f4.ld TARGET_FILE_NAME=$@
 
 #
 # Show sizes

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ all:	$(TARGETS)
 
 clean:
 	cd libopencm3 && make --no-print-directory clean && cd ..
-	rm -f *.elf *.bin *.o *.d
+	rm -r build_*
 
 #
 # Specific bootloader targets.

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,7 @@ all:	$(TARGETS) sizes
 
 clean:
 	cd libopencm3 && make --no-print-directory clean && cd ..
+	rm -f *.elf *.bin
 	rm -rf build_*
 
 #

--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ aerofcv1_bl: $(MAKEFILE_LIST) $(LIBOPENCM3)
 #
 .PHONY: sizes
 sizes:
-	@-find build_* -name *.elf -type f | xargs size 2> /dev/null || :
+	@-find build_* -name '*.elf' -type f | xargs size 2> /dev/null || :
 
 #
 # Binary management

--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ aerofcv1_bl: $(MAKEFILE_LIST) $(LIBOPENCM3)
 #
 .PHONY: deploy
 deploy:
-	zip Bootloader.zip *.bin
+	zip -j Bootloader.zip build_*/*.bin
 
 #
 # Submodule management

--- a/Makefile
+++ b/Makefile
@@ -131,7 +131,7 @@ deploy:
 #
 
 $(LIBOPENCM3): checksubmodules
-	make -C $(LIBOPENCM3) lib
+	${MAKE} -C $(LIBOPENCM3) lib
 
 .PHONY: checksubmodules
 checksubmodules: updatesubmodules

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ all:	$(TARGETS)
 
 clean:
 	cd libopencm3 && make --no-print-directory clean && cd ..
-	rm -f *.elf *.bin
+	rm -f *.elf *.bin *.o *.d
 
 #
 # Specific bootloader targets.

--- a/Makefile
+++ b/Makefile
@@ -53,8 +53,7 @@ TARGETS	= \
 	px4iov3_bl \
 	tapv1_bl
 
-all:	$(TARGETS)
-
+all:	$(TARGETS) sizes
 
 clean:
 	cd libopencm3 && make --no-print-directory clean && cd ..
@@ -112,6 +111,13 @@ tapv1_bl: $(MAKEFILE_LIST) $(LIBOPENCM3)
 
 aerofcv1_bl: $(MAKEFILE_LIST) $(LIBOPENCM3)
 	make -f Makefile.f4 TARGET_HW=AEROFC_V1 LINKER_FILE=stm32f4.ld TARGET_FILE_NAME=$@
+
+#
+# Show sizes
+#
+.PHONY: sizes
+sizes:
+	@-find build_* -name *.elf -type f | xargs size 2> /dev/null || :
 
 #
 # Binary management

--- a/Makefile.f1
+++ b/Makefile.f1
@@ -12,9 +12,6 @@ PX4_BOOTLOADER_DELAY	?= 3000
 
 SRCS		 = $(COMMON_SRCS) main_f1.c
 
-OBJS		:= $(patsubst %.c,%.o,$(SRCS))
-DEPS		:= $(OBJS:.o=.d)
-
 FLAGS		+= -mthumb -mcpu=cortex-m3\
        -DTARGET_HW_$(TARGET_HW) \
        -DSTM32F1 \
@@ -22,27 +19,13 @@ FLAGS		+= -mthumb -mcpu=cortex-m3\
 		   -L$(LIBOPENCM3)/lib \
 		   -lopencm3_stm32f1
 
-ELF		 = $(TARGET_FILE_NAME).elf
-BINARY		 = $(TARGET_FILE_NAME).bin
-
-all:		$(ELF) $(BINARY)
-
-# Compile and generate dependency files
-$(OBJS):	$(SRCS)
-	$(CC) -c $(FLAGS) $*.c -o $*.o
-	$(CC) -MM $(FLAGS) $*.c > $*.d
-
-$(ELF):		$(OBJS) $(MAKEFILE_LIST)
-	$(CC) -o $@ $(OBJS) $(FLAGS)
-
-$(BINARY):	$(ELF)
-	$(OBJCOPY) -O binary $(ELF) $(BINARY)
+#
+# General rules for making dependency and object files
+# This is where the compiler is called
+#
 
 #upload: all flash flash-bootloader
 upload: all flash-bootloader
 
 flash-bootloader:
 	$(OPENOCD) --search ../px4_bootloader -f $(JTAGCONFIG) -f stm32f1.cfg -c init -c "reset halt" -c "flash write_image erase $(BINARY)" -c "reset run" -c shutdown
-
-# Dependencies for .o files
--include $(DEPS)

--- a/Makefile.f1
+++ b/Makefile.f1
@@ -29,4 +29,4 @@ include rules.mk
 upload: all flash-bootloader
 
 flash-bootloader:
-	$(OPENOCD) --search ../px4_bootloader -f $(JTAGCONFIG) -f stm32f1.cfg -c init -c "reset halt" -c "flash write_image erase $(BUILD_DIR)/$(BINARY)" -c "reset run" -c shutdown
+	$(OPENOCD) --search ../px4_bootloader -f $(JTAGCONFIG) -f stm32f1.cfg -c init -c "reset halt" -c "flash write_image erase $(BINARY)" -c "reset run" -c shutdown

--- a/Makefile.f1
+++ b/Makefile.f1
@@ -12,6 +12,9 @@ PX4_BOOTLOADER_DELAY	?= 3000
 
 SRCS		 = $(COMMON_SRCS) main_f1.c
 
+OBJS		:= $(patsubst %.c,%.o,$(SRCS))
+DEPS		:= $(OBJS:.o=.d)
+
 FLAGS		+= -mthumb -mcpu=cortex-m3\
        -DTARGET_HW_$(TARGET_HW) \
        -DSTM32F1 \
@@ -24,8 +27,13 @@ BINARY		 = $(TARGET_FILE_NAME).bin
 
 all:		$(ELF) $(BINARY)
 
-$(ELF):		$(SRCS) $(MAKEFILE_LIST)
-	$(CC) -o $@ $(SRCS) $(FLAGS)
+# Compile and generate dependency files
+$(OBJS):	$(SRCS)
+	$(CC) -c $(FLAGS) $*.c -o $*.o
+	$(CC) -MM $(FLAGS) $*.c > $*.d
+
+$(ELF):		$(OBJS) $(MAKEFILE_LIST)
+	$(CC) -o $@ $(OBJS) $(FLAGS)
 
 $(BINARY):	$(ELF)
 	$(OBJCOPY) -O binary $(ELF) $(BINARY)
@@ -35,3 +43,6 @@ upload: all flash-bootloader
 
 flash-bootloader:
 	$(OPENOCD) --search ../px4_bootloader -f $(JTAGCONFIG) -f stm32f1.cfg -c init -c "reset halt" -c "flash write_image erase $(BINARY)" -c "reset run" -c shutdown
+
+# Dependencies for .o files
+-include $(DEPS)

--- a/Makefile.f1
+++ b/Makefile.f1
@@ -23,9 +23,10 @@ FLAGS		+= -mthumb -mcpu=cortex-m3\
 # General rules for making dependency and object files
 # This is where the compiler is called
 #
+include rules.mk
 
 #upload: all flash flash-bootloader
 upload: all flash-bootloader
 
 flash-bootloader:
-	$(OPENOCD) --search ../px4_bootloader -f $(JTAGCONFIG) -f stm32f1.cfg -c init -c "reset halt" -c "flash write_image erase $(BINARY)" -c "reset run" -c shutdown
+	$(OPENOCD) --search ../px4_bootloader -f $(JTAGCONFIG) -f stm32f1.cfg -c init -c "reset halt" -c "flash write_image erase $(BUILD_DIR)/$(BINARY)" -c "reset run" -c shutdown

--- a/Makefile.f3
+++ b/Makefile.f3
@@ -12,10 +12,7 @@ PX4_BOOTLOADER_DELAY	?= 5000
 
 SRCS		 = $(COMMON_SRCS) main_f3.c
 
-OBJS		:= $(patsubst %.c,%.o,$(SRCS))
-DEPS		:= $(OBJS:.o=.d)
-
-FLAGS		+= -mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16 \
+FLAGS 		+= -mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16 \
        -DTARGET_HW_$(TARGET_HW) \
        -DSTM32F3 \
        -T$(LINKER_FILE) \
@@ -23,27 +20,14 @@ FLAGS		+= -mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16 \
 		   -lopencm3_stm32f3 \
         $(EXTRAFLAGS)
 
-ELF		 = $(TARGET_FILE_NAME).elf
-BINARY		 = $(TARGET_FILE_NAME).bin
-
-all:		$(ELF) $(BINARY)
-
-# Compile and generate dependency files
-$(OBJS):	$(SRCS)
-	$(CC) -c $(FLAGS) $*.c -o $*.o
-	$(CC) -MM $(FLAGS) $*.c > $*.d
-
-$(ELF):		$(OBJS) $(MAKEFILE_LIST)
-	$(CC) -o $@ $(OBJS) $(FLAGS)
-
-$(BINARY):	$(ELF)
-	$(OBJCOPY) -O binary $(ELF) $(BINARY)
+#
+# General rules for making dependency and object files
+# This is where the compiler is called
+#
+include rules.mk
 
 #upload: all flash flash-bootloader
 upload: all flash-bootloader
 
 flash-bootloader:
 	$(OPENOCD) --search ../px4_bootloader -f $(JTAGCONFIG) -f stm32f3x.cfg -c init -c "reset halt" -c "flash write_image erase $(BINARY) 0x08000000" -c "reset run" -c shutdown
-
-# Dependencies for .o files
--include $(DEPS)

--- a/Makefile.f3
+++ b/Makefile.f3
@@ -12,6 +12,9 @@ PX4_BOOTLOADER_DELAY	?= 5000
 
 SRCS		 = $(COMMON_SRCS) main_f3.c
 
+OBJS		:= $(patsubst %.c,%.o,$(SRCS))
+DEPS		:= $(OBJS:.o=.d)
+
 FLAGS		+= -mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16 \
        -DTARGET_HW_$(TARGET_HW) \
        -DSTM32F3 \
@@ -25,8 +28,13 @@ BINARY		 = $(TARGET_FILE_NAME).bin
 
 all:		$(ELF) $(BINARY)
 
-$(ELF):		$(SRCS) $(MAKEFILE_LIST)
-	$(CC) -o $@ $(SRCS) $(FLAGS)
+# Compile and generate dependency files
+$(OBJS):	$(SRCS)
+	$(CC) -c $(FLAGS) $*.c -o $*.o
+	$(CC) -MM $(FLAGS) $*.c > $*.d
+
+$(ELF):		$(OBJS) $(MAKEFILE_LIST)
+	$(CC) -o $@ $(OBJS) $(FLAGS)
 
 $(BINARY):	$(ELF)
 	$(OBJCOPY) -O binary $(ELF) $(BINARY)
@@ -36,3 +44,6 @@ upload: all flash-bootloader
 
 flash-bootloader:
 	$(OPENOCD) --search ../px4_bootloader -f $(JTAGCONFIG) -f stm32f3x.cfg -c init -c "reset halt" -c "flash write_image erase $(BINARY) 0x08000000" -c "reset run" -c shutdown
+
+# Dependencies for .o files
+-include $(DEPS)

--- a/Makefile.f3
+++ b/Makefile.f3
@@ -30,4 +30,4 @@ include rules.mk
 upload: all flash-bootloader
 
 flash-bootloader:
-	$(OPENOCD) --search ../px4_bootloader -f $(JTAGCONFIG) -f stm32f3x.cfg -c init -c "reset halt" -c "flash write_image erase $(BINARY) 0x08000000" -c "reset run" -c shutdown
+	$(OPENOCD) --search ../px4_bootloader -f $(JTAGCONFIG) -f stm32f3x.cfg -c init -c "reset halt" -c "flash write_image erase $(BUILD_DIR)/$(BINARY) 0x08000000" -c "reset run" -c shutdown

--- a/Makefile.f3
+++ b/Makefile.f3
@@ -30,4 +30,4 @@ include rules.mk
 upload: all flash-bootloader
 
 flash-bootloader:
-	$(OPENOCD) --search ../px4_bootloader -f $(JTAGCONFIG) -f stm32f3x.cfg -c init -c "reset halt" -c "flash write_image erase $(BUILD_DIR)/$(BINARY) 0x08000000" -c "reset run" -c shutdown
+	$(OPENOCD) --search ../px4_bootloader -f $(JTAGCONFIG) -f stm32f3x.cfg -c init -c "reset halt" -c "flash write_image erase $(BINARY) 0x08000000" -c "reset run" -c shutdown

--- a/Makefile.f4
+++ b/Makefile.f4
@@ -33,9 +33,9 @@ include rules.mk
 upload: all flash-bootloader
 
 flash-bootloader:
-	$(OPENOCD) --search ../px4_bootloader -f $(JTAGCONFIG) -f stm32f4x.cfg -c init -c "reset halt" -c "flash write_image erase $(BINARY) 0x08000000" -c "reset run" -c shutdown
+	$(OPENOCD) --search ../px4_bootloader -f $(JTAGCONFIG) -f stm32f4x.cfg -c init -c "reset halt" -c "flash write_image erase $(BUILD_DIR)/$(BINARY) 0x08000000" -c "reset run" -c shutdown
 
 # Use to upload to a stm32f4-discovery devboard, requires the latest version of openocd (from git)
 # build openocd with "cd openocd; ./bootstrap; ./configure --enable-maintainer-mode --enable-stlink"
 upload-discovery: 
-	$(OPENOCD) --search ../px4_bootloader -f board/stm32f4discovery.cfg -c init -c "reset halt" -c "flash probe 0" -c "stm32f2x mass_erase 0" -c "flash write_image erase $(BINARY) 0x08000000" -c "reset" -c shutdown
+	$(OPENOCD) --search ../px4_bootloader -f board/stm32f4discovery.cfg -c init -c "reset halt" -c "flash probe 0" -c "stm32f2x mass_erase 0" -c "flash write_image erase $(BUILD_DIR)/$(BINARY) 0x08000000" -c "reset" -c shutdown

--- a/Makefile.f4
+++ b/Makefile.f4
@@ -33,9 +33,9 @@ include rules.mk
 upload: all flash-bootloader
 
 flash-bootloader:
-	$(OPENOCD) --search ../px4_bootloader -f $(JTAGCONFIG) -f stm32f4x.cfg -c init -c "reset halt" -c "flash write_image erase $(BUILD_DIR)/$(BINARY) 0x08000000" -c "reset run" -c shutdown
+	$(OPENOCD) --search ../px4_bootloader -f $(JTAGCONFIG) -f stm32f4x.cfg -c init -c "reset halt" -c "flash write_image erase $(BINARY) 0x08000000" -c "reset run" -c shutdown
 
 # Use to upload to a stm32f4-discovery devboard, requires the latest version of openocd (from git)
 # build openocd with "cd openocd; ./bootstrap; ./configure --enable-maintainer-mode --enable-stlink"
 upload-discovery: 
-	$(OPENOCD) --search ../px4_bootloader -f board/stm32f4discovery.cfg -c init -c "reset halt" -c "flash probe 0" -c "stm32f2x mass_erase 0" -c "flash write_image erase $(BUILD_DIR)/$(BINARY) 0x08000000" -c "reset" -c shutdown
+	$(OPENOCD) --search ../px4_bootloader -f board/stm32f4discovery.cfg -c init -c "reset halt" -c "flash probe 0" -c "stm32f2x mass_erase 0" -c "flash write_image erase $(BINARY) 0x08000000" -c "reset" -c shutdown

--- a/Makefile.f4
+++ b/Makefile.f4
@@ -23,21 +23,11 @@ FLAGS		+= -mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16 \
 		   -lopencm3_stm32f4 \
         $(EXTRAFLAGS)
 
-ELF		 = $(TARGET_FILE_NAME).elf
-BINARY		 = $(TARGET_FILE_NAME).bin
-
-all:		$(ELF) $(BINARY)
-
-# Compile and generate dependency files
-$(OBJS):	$(SRCS)
-	$(CC) -c $(FLAGS) $*.c -o $*.o
-	$(CC) -MM $(FLAGS) $*.c > $*.d
-
-$(ELF):		$(OBJS) $(MAKEFILE_LIST)
-	$(CC) -o $@ $(OBJS) $(FLAGS)
-
-$(BINARY):	$(ELF)
-	$(OBJCOPY) -O binary $(ELF) $(BINARY)
+#
+# General rules for making dependency and object files
+# This is where the compiler is called
+#
+include rules.mk
 
 #upload: all flash flash-bootloader
 upload: all flash-bootloader
@@ -49,6 +39,3 @@ flash-bootloader:
 # build openocd with "cd openocd; ./bootstrap; ./configure --enable-maintainer-mode --enable-stlink"
 upload-discovery: 
 	$(OPENOCD) --search ../px4_bootloader -f board/stm32f4discovery.cfg -c init -c "reset halt" -c "flash probe 0" -c "stm32f2x mass_erase 0" -c "flash write_image erase $(BINARY) 0x08000000" -c "reset" -c shutdown
-
-# Dependencies for .o files
--include $(DEPS)

--- a/Makefile.f4
+++ b/Makefile.f4
@@ -12,6 +12,9 @@ PX4_BOOTLOADER_DELAY	?= 5000
 
 SRCS		 = $(COMMON_SRCS) main_f4.c
 
+OBJS		:= $(patsubst %.c,%.o,$(SRCS))
+DEPS		:= $(OBJS:.o=.d)
+
 FLAGS		+= -mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16 \
        -DTARGET_HW_$(TARGET_HW) \
        -DSTM32F4 \
@@ -25,8 +28,13 @@ BINARY		 = $(TARGET_FILE_NAME).bin
 
 all:		$(ELF) $(BINARY)
 
-$(ELF):		$(SRCS) $(MAKEFILE_LIST)
-	$(CC) -o $@ $(SRCS) $(FLAGS)
+# Compile and generate dependency files
+$(OBJS):	$(SRCS)
+	$(CC) -c $(FLAGS) $*.c -o $*.o
+	$(CC) -MM $(FLAGS) $*.c > $*.d
+
+$(ELF):		$(OBJS) $(MAKEFILE_LIST)
+	$(CC) -o $@ $(OBJS) $(FLAGS)
 
 $(BINARY):	$(ELF)
 	$(OBJCOPY) -O binary $(ELF) $(BINARY)
@@ -41,3 +49,6 @@ flash-bootloader:
 # build openocd with "cd openocd; ./bootstrap; ./configure --enable-maintainer-mode --enable-stlink"
 upload-discovery: 
 	$(OPENOCD) --search ../px4_bootloader -f board/stm32f4discovery.cfg -c init -c "reset halt" -c "flash probe 0" -c "stm32f2x mass_erase 0" -c "flash write_image erase $(BINARY) 0x08000000" -c "reset" -c shutdown
+
+# Dependencies for .o files
+-include $(DEPS)

--- a/Makefile.f7
+++ b/Makefile.f7
@@ -14,9 +14,6 @@ PX4_BOOTLOADER_DELAY	?= 5000
 
 SRCS		 = $(COMMON_SRCS) main_f7.c
 
-OBJS		:= $(patsubst %.c,%.o,$(SRCS))
-DEPS		:= $(OBJS:.o=.d)
-
 FLAGS		+= -g -mthumb -mcpu=cortex-m7 -mfloat-abi=hard -mfpu=fpv5-sp-d16 \
        -DTARGET_HW_$(TARGET_HW) \
        -DSTM32F4 \
@@ -25,27 +22,14 @@ FLAGS		+= -g -mthumb -mcpu=cortex-m7 -mfloat-abi=hard -mfpu=fpv5-sp-d16 \
 		   -lopencm3_stm32f4 \
         $(EXTRAFLAGS)
 
-ELF		 = $(TARGET_FILE_NAME).elf
-BINARY		 = $(TARGET_FILE_NAME).bin
-
-all:		$(ELF) $(BINARY)
-
-# Compile and generate dependency files
-$(OBJS):	$(SRCS)
-	$(CC) -c $(FLAGS) $*.c -o $*.o
-	$(CC) -MM $(FLAGS) $*.c > $*.d
-
-$(ELF):		$(OBJS) $(MAKEFILE_LIST)
-	$(CC) -o $@ $(OBJS) $(FLAGS)
-
-$(BINARY):	$(ELF)
-	$(OBJCOPY) -O binary $(ELF) $(BINARY)
+#
+# General rules for making dependency and object files
+# This is where the compiler is called
+#
+include rules.mk
 
 #upload: all flash flash-bootloader
 upload: all flash-bootloader
 
 flash-bootloader:
 	$(OPENOCD) --search ../px4_bootloader -f $(JTAGCONFIG) -f stm32f4x.cfg -c init -c "reset halt" -c "flash write_image erase $(BINARY) 0x08000000" -c "reset run" -c shutdown
-
-# Dependencies for .o files
--include $(DEPS)

--- a/Makefile.f7
+++ b/Makefile.f7
@@ -14,6 +14,9 @@ PX4_BOOTLOADER_DELAY	?= 5000
 
 SRCS		 = $(COMMON_SRCS) main_f7.c
 
+OBJS		:= $(patsubst %.c,%.o,$(SRCS))
+DEPS		:= $(OBJS:.o=.d)
+
 FLAGS		+= -g -mthumb -mcpu=cortex-m7 -mfloat-abi=hard -mfpu=fpv5-sp-d16 \
        -DTARGET_HW_$(TARGET_HW) \
        -DSTM32F4 \
@@ -27,8 +30,13 @@ BINARY		 = $(TARGET_FILE_NAME).bin
 
 all:		$(ELF) $(BINARY)
 
-$(ELF):		$(SRCS) $(MAKEFILE_LIST)
-	$(CC) -o $@ $(SRCS) $(FLAGS)
+# Compile and generate dependency files
+$(OBJS):	$(SRCS)
+	$(CC) -c $(FLAGS) $*.c -o $*.o
+	$(CC) -MM $(FLAGS) $*.c > $*.d
+
+$(ELF):		$(OBJS) $(MAKEFILE_LIST)
+	$(CC) -o $@ $(OBJS) $(FLAGS)
 
 $(BINARY):	$(ELF)
 	$(OBJCOPY) -O binary $(ELF) $(BINARY)
@@ -38,3 +46,6 @@ upload: all flash-bootloader
 
 flash-bootloader:
 	$(OPENOCD) --search ../px4_bootloader -f $(JTAGCONFIG) -f stm32f4x.cfg -c init -c "reset halt" -c "flash write_image erase $(BINARY) 0x08000000" -c "reset run" -c shutdown
+
+# Dependencies for .o files
+-include $(DEPS)

--- a/Makefile.f7
+++ b/Makefile.f7
@@ -32,4 +32,4 @@ include rules.mk
 upload: all flash-bootloader
 
 flash-bootloader:
-	$(OPENOCD) --search ../px4_bootloader -f $(JTAGCONFIG) -f stm32f4x.cfg -c init -c "reset halt" -c "flash write_image erase $(BUILD_DIR)/$(BINARY) 0x08000000" -c "reset run" -c shutdown
+	$(OPENOCD) --search ../px4_bootloader -f $(JTAGCONFIG) -f stm32f4x.cfg -c init -c "reset halt" -c "flash write_image erase $(BINARY) 0x08000000" -c "reset run" -c shutdown

--- a/Makefile.f7
+++ b/Makefile.f7
@@ -32,4 +32,4 @@ include rules.mk
 upload: all flash-bootloader
 
 flash-bootloader:
-	$(OPENOCD) --search ../px4_bootloader -f $(JTAGCONFIG) -f stm32f4x.cfg -c init -c "reset halt" -c "flash write_image erase $(BINARY) 0x08000000" -c "reset run" -c shutdown
+	$(OPENOCD) --search ../px4_bootloader -f $(JTAGCONFIG) -f stm32f4x.cfg -c init -c "reset halt" -c "flash write_image erase $(BUILD_DIR)/$(BINARY) 0x08000000" -c "reset run" -c shutdown

--- a/rules.mk
+++ b/rules.mk
@@ -5,6 +5,8 @@
 OBJS		:= $(patsubst %.c,%.o,$(SRCS))
 DEPS		:= $(OBJS:.o=.d)
 
+BUILD_DIR	 = build_$(TARGET_FILE_NAME)
+
 ELF		 = $(TARGET_FILE_NAME).elf
 BINARY		 = $(TARGET_FILE_NAME).bin
 
@@ -12,15 +14,15 @@ all:		$(ELF) $(BINARY)
 
 # Compile and generate dependency files
 $(OBJS):	$(SRCS)
-	$(CC) -c $(FLAGS) $*.c -o $*.o
-	$(CC) -MM $(FLAGS) $*.c > $*.d
+	mkdir -p $(BUILD_DIR)
+	$(CC) -c $(FLAGS) $*.c -o $(BUILD_DIR)/$*.o
+	$(CC) -MM $(FLAGS) $*.c > $(BUILD_DIR)/$*.d
 
 $(ELF):		$(OBJS) $(MAKEFILE_LIST)
-	$(CC) -o $@ $(OBJS) $(FLAGS)
+	$(CC) -o $(BUILD_DIR)/$@ $(addprefix $(BUILD_DIR)/, $(OBJS)) $(FLAGS)
 
 $(BINARY):	$(ELF)
-	$(OBJCOPY) -O binary $(ELF) $(BINARY)
-
+	$(OBJCOPY) -O binary $(BUILD_DIR)/$(ELF) $(BUILD_DIR)/$(BINARY)
 
 # Dependencies for .o files
--include $(DEPS)
+-include $(BUILD_DIR)/$(DEPS)

--- a/rules.mk
+++ b/rules.mk
@@ -1,0 +1,26 @@
+#
+# Common rules for makefiles for the PX4 bootloaders
+#
+
+OBJS		:= $(patsubst %.c,%.o,$(SRCS))
+DEPS		:= $(OBJS:.o=.d)
+
+ELF		 = $(TARGET_FILE_NAME).elf
+BINARY		 = $(TARGET_FILE_NAME).bin
+
+all:		$(ELF) $(BINARY)
+
+# Compile and generate dependency files
+$(OBJS):	$(SRCS)
+	$(CC) -c $(FLAGS) $*.c -o $*.o
+	$(CC) -MM $(FLAGS) $*.c > $*.d
+
+$(ELF):		$(OBJS) $(MAKEFILE_LIST)
+	$(CC) -o $@ $(OBJS) $(FLAGS)
+
+$(BINARY):	$(ELF)
+	$(OBJCOPY) -O binary $(ELF) $(BINARY)
+
+
+# Dependencies for .o files
+-include $(DEPS)


### PR DESCRIPTION
This resolves the issue (#77) that if any of the header header files were
modified, make would not recompile to include the changes in the header
files the unless clean was run before recompiling.

.o object files and .d dependency files are created for each of the c files. The only proviso is that if a header file is renamed, the dependency will be "lost" so you will have to `make clean` before recompiling.