### PR TITLE
initial omnibusf4sd target support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,7 @@ TARGETS	= \
 	auavx2v1_bl \
 	crazyflie_bl \
 	mindpxv2_bl \
+	omnibusf4sd_bl \
 	px4aerocore_bl \
 	px4discovery_bl \
 	px4flow_bl \
@@ -98,6 +99,9 @@ px4aerocore_bl: $(MAKEFILE_LIST) $(LIBOPENCM3)
 
 crazyflie_bl: $(MAKEFILE_LIST) $(LIBOPENCM3)
 	${MAKE} ${MKFLAGS} -f  Makefile.f4 TARGET_HW=CRAZYFLIE LINKER_FILE=stm32f4.ld TARGET_FILE_NAME=$@
+
+omnibusf4sd_bl: $(MAKEFILE_LIST) $(LIBOPENCM3)
+	${MAKE} ${MKFLAGS} -f  Makefile.f4 TARGET_HW=OMNIBUSF4SD LINKER_FILE=stm32f4.ld TARGET_FILE_NAME=$@
 
 cube_f4_bl: $(MAKEFILE_LIST) $(LIBOPENCM3)
 	${MAKE} ${MKFLAGS} -f  Makefile.f4 TARGET_HW=CUBE_F4  LINKER_FILE=stm32f4.ld TARGET_FILE_NAME=$@

--- a/hw_config.h
+++ b/hw_config.h
@@ -643,6 +643,39 @@
 # define USBMFGSTRING                   "Bitcraze AB"
 
 /****************************************************************************
+ * TARGET_HW_OMNIBUS_NXT
+ ****************************************************************************/
+
+#elif  defined(TARGET_HW_OMNIBUSF4SD)
+
+# define APP_LOAD_ADDRESS               0x08004000
+# define BOOTLOADER_DELAY               5000
+# define BOARD_OMNIBUSF4SD
+# define INTERFACE_USB                  1
+# define INTERFACE_USART                0
+# define USBDEVICESTRING                "OmnibusF4SD"
+# define USBPRODUCTID                   0x0016
+
+# define BOARD_TYPE                     42
+# define BOARD_FLASH_SECTORS            11
+# define BOARD_FLASH_SIZE               (1024 * 1024)
+
+# define OSC_FREQ                       8
+
+# define BOARD_PIN_LED_ACTIVITY         GPIO5
+# define BOARD_PIN_LED_BOOTLOADER       GPIO4
+# define BOARD_PORT_LEDS                GPIOB
+# define BOARD_CLOCK_LEDS               RCC_AHB1ENR_IOPBEN
+# define BOARD_LED_ON                   gpio_clear
+# define BOARD_LED_OFF                  gpio_set
+
+# define BOARD_USB_VBUS_SENSE_DISABLED
+//# define BOARD_PIN_VBUS                 GPIO5
+//# define BOARD_PORT_VBUS                GPIOC
+
+# define USBMFGSTRING                   "Vertile"
+
+/****************************************************************************
  * TARGET_HW_AUAV_X2V1
  ****************************************************************************/
 

--- a/main_f4.c
+++ b/main_f4.c
@@ -81,6 +81,12 @@ static struct {
 #define REVID_MASK	0xFFFF0000
 #define DEVID_MASK	0xFFF
 
+#ifndef BOARD_PIN_VBUS
+# define BOARD_PIN_VBUS                 GPIO9
+# define BOARD_PORT_VBUS                GPIOA
+# define BOARD_CLOCK_VBUS               RCC_AHB1ENR_IOPAEN
+#endif
+
 /* magic numbers from reference manual */
 
 typedef enum mcu_rev_e {
@@ -349,8 +355,7 @@ board_init(void)
 
 #if INTERFACE_USB
 
-	/* enable Port A GPIO9 to sample VBUS */
-	rcc_peripheral_enable_clock(&RCC_AHB1ENR, RCC_AHB1ENR_IOPAEN);
+	rcc_peripheral_enable_clock(&RCC_AHB1ENR, BOARD_CLOCK_VBUS);
 #endif
 
 #if INTERFACE_USART
@@ -781,7 +786,7 @@ main(void)
 #if defined(BOARD_USB_VBUS_SENSE_DISABLED)
 	try_boot = false;
 #else
-	if (gpio_get(GPIOA, GPIO9) != 0) {
+	if (gpio_get(BOARD_PORT_VBUS, BOARD_PIN_VBUS) != 0) {
 
 		/* don't try booting before we set up the bootloader */
 		try_boot = false;


### PR DESCRIPTION
bootloader support for the [omnibusf4sd](https://github.com/betaflight/betaflight/wiki/Board---OMNIBUSF4)

this is tested and working with my 1.7.4 branch: https://github.com/nathantsoi/Firmware/tree/omnibusf4sd-1.7.4

full details and status of the port here, any guidance would be much appreciated: http://discuss.px4.io/t/omnibusf4sd-target-support-request-for-development-guidance/6373