### PR TITLE
added board_types.txt to hold all BOARD_TYPE values

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,6 @@ TARGETS	= \
 	px4iov3_bl \
 	tapv1_bl \
 	cube_f4_bl \
-	cube_f7_bl \
 	avx_v1_bl
 
 all:	$(TARGETS) sizes

--- a/bl.c
+++ b/bl.c
@@ -103,6 +103,7 @@
 #define PROTO_GET_CHIP_DES			0x2e    // read chip version In ASCII
 #define PROTO_BOOT					0x30    // boot the application
 #define PROTO_DEBUG					0x31    // emit debug information - format not defined
+#define PROTO_SET_BAUD				0x33    // set baud rate on uart
 
 #define PROTO_PROG_MULTI_MAX    64	// maximum PROG_MULTI size
 #define PROTO_READ_MULTI_MAX    255	// size of the size field

--- a/board_types.txt
+++ b/board_types.txt
@@ -41,4 +41,5 @@ AP_HW_AIRBOTF4                        128
 AP_HW_SPARKYV2                        130
 AP_HW_OMNIBUSF4PRO                    131
 AP_HW_ANYFCF7                         132
+AP_HW_OMNIBUSNANOV6                   133
 AP_HW_F4BY                             20 # value due to previous release by vendor

--- a/board_types.txt
+++ b/board_types.txt
@@ -20,7 +20,6 @@ TARGET_HW_OMNIBUSF4SD                  42
 TARGET_HW_AUAV_X2V1                    33
 TARGET_HW_AEROFC_V1                    65
 TARGET_HW_CUBE_F4                       9
-TARGET_HW_CUBE_F7                      50
 
 # values from external vendors
 EXT_HW_RADIOLINK_MINI_PIX               3

--- a/board_types.txt
+++ b/board_types.txt
@@ -40,4 +40,5 @@ AP_HW_AIRBOTF4                        128
 AP_HW_F4BY                            129
 AP_HW_SPARKYV2                        130
 AP_HW_OMNIBUSF4PRO                    131
+AP_HW_ANYFCF7                         132
 

--- a/board_types.txt
+++ b/board_types.txt
@@ -31,3 +31,5 @@ AP_HW_KAKUTEF7                        123
 AP_HW_REVOLUTION                      124
 AP_HW_MATEKF405                       125
 AP_HW_NUCLEOF767ZI                    126
+AP_HW_MATEKF405_WING                  127
+

--- a/board_types.txt
+++ b/board_types.txt
@@ -21,3 +21,12 @@ TARGET_HW_AUAV_X2V1                    33
 TARGET_HW_AEROFC_V1                    65
 TARGET_HW_CUBE_F4                       9
 TARGET_HW_CUBE_F7                      50
+
+
+# values below this line are implemented in the ArduPilot bootloader
+AP_HW_CUBE_ORANGE                     120
+AP_HW_OMNIBUSF7V2                     121
+AP_HW_KAKUTEF4                        122
+AP_HW_KAKUTEF7                        123
+AP_HW_REVOLUTION                      124
+AP_HW_MATEKF405                       125

--- a/board_types.txt
+++ b/board_types.txt
@@ -26,6 +26,9 @@ TARGET_HW_CUBE_F7                      50
 EXT_HW_RADIOLINK_MINI_PIX               3
 
 # values starting with AP_ are implemented in the ArduPilot bootloader
+# https://github.com/ArduPilot/ardupilot/tree/master/Tools/AP_Bootloader
+# the values come from the APJ_BOARD_ID in the hwdef files here:
+# https://github.com/ArduPilot/ardupilot/tree/master/libraries/AP_HAL_ChibiOS/hwdef
 AP_HW_CUBE_ORANGE                     120
 AP_HW_OMNIBUSF7V2                     121
 AP_HW_KAKUTEF4                        122

--- a/board_types.txt
+++ b/board_types.txt
@@ -39,3 +39,5 @@ AP_HW_MATEKF405_WING                  127
 AP_HW_AIRBOTF4                        128
 AP_HW_F4BY                            129
 AP_HW_SPARKYV2                        130
+AP_HW_OMNIBUSF4PRO                    131
+

--- a/board_types.txt
+++ b/board_types.txt
@@ -1,0 +1,23 @@
+# this file lists all board types for boards that use the bootloader
+# protocol implemented in this bootloader.
+
+TARGET_HW_PX4_FMU_V1                    5
+TARGET_HW_PX4_FMU_V2                    9
+TARGET_HW_PX4_FMU_V3                    9 # same as FMU_V2
+TARGET_HW_PX4_FMU_V4                   11
+TARGET_HW_PX4_FMU_V4_PRO               13
+TARGET_HW_PX4_FMU_V5                   50
+TARGET_HW_MINDPX_V2                    88
+TARGET_HW_PX4_FLOW_V1                   6
+TARGET_HW_PX4_DISCOVERY_V1             99
+TARGET_HW_PX4_PIO_V1                   10
+TARGET_HW_PX4_PIO_V2                   10 # same as PIO_V1
+TARGET_HW_PX4_PIO_V3                   13
+TARGET_HW_PX4_AEROCORE_V1              98
+TARGET_HW_TAP_V1                       64
+TARGET_HW_CRAZYFLIE                    12
+TARGET_HW_OMNIBUSF4SD                  42
+TARGET_HW_AUAV_X2V1                    33
+TARGET_HW_AEROFC_V1                    65
+TARGET_HW_CUBE_F4                       9
+TARGET_HW_CUBE_F7                      50

--- a/board_types.txt
+++ b/board_types.txt
@@ -20,6 +20,7 @@ TARGET_HW_OMNIBUSF4SD                  42
 TARGET_HW_AUAV_X2V1                    33
 TARGET_HW_AEROFC_V1                    65
 TARGET_HW_CUBE_F4                       9
+TARGET_HW_AV_V1                        29
 
 # values from external vendors
 EXT_HW_RADIOLINK_MINI_PIX               3
@@ -37,8 +38,7 @@ AP_HW_MATEKF405                       125
 AP_HW_NUCLEOF767ZI                    126
 AP_HW_MATEKF405_WING                  127
 AP_HW_AIRBOTF4                        128
-AP_HW_F4BY                            129
 AP_HW_SPARKYV2                        130
 AP_HW_OMNIBUSF4PRO                    131
 AP_HW_ANYFCF7                         132
-
+AP_HW_F4BY                             20 # value due to previous release by vendor

--- a/board_types.txt
+++ b/board_types.txt
@@ -22,8 +22,10 @@ TARGET_HW_AEROFC_V1                    65
 TARGET_HW_CUBE_F4                       9
 TARGET_HW_CUBE_F7                      50
 
+# values from external vendors
+EXT_HW_RADIOLINK_MINI_PIX               3
 
-# values below this line are implemented in the ArduPilot bootloader
+# values starting with AP_ are implemented in the ArduPilot bootloader
 AP_HW_CUBE_ORANGE                     120
 AP_HW_OMNIBUSF7V2                     121
 AP_HW_KAKUTEF4                        122
@@ -32,4 +34,6 @@ AP_HW_REVOLUTION                      124
 AP_HW_MATEKF405                       125
 AP_HW_NUCLEOF767ZI                    126
 AP_HW_MATEKF405_WING                  127
-
+AP_HW_AIRBOTF4                        128
+AP_HW_F4BY                            129
+AP_HW_SPARKYV2                        130

--- a/board_types.txt
+++ b/board_types.txt
@@ -30,3 +30,4 @@ AP_HW_KAKUTEF4                        122
 AP_HW_KAKUTEF7                        123
 AP_HW_REVOLUTION                      124
 AP_HW_MATEKF405                       125
+AP_HW_NUCLEOF767ZI                    126

--- a/hw_config.h
+++ b/hw_config.h
@@ -932,62 +932,6 @@
  */
 
 /****************************************************************************
- * TARGET_HW_CUBE_F7
- ****************************************************************************/
-
-#elif  defined(TARGET_HW_CUBE_F7)
-
-# define APP_LOAD_ADDRESS               0x08008000
-# define BOOTLOADER_DELAY               5000
-# define INTERFACE_USB                  1
-# define INTERFACE_USART                1
-# define USBDEVICESTRING                "ProfiCNC CUBE F7 BL"
-# define USBPRODUCTID                   0x0002
-# define USBMFGSTRING                   "Hex Technology Limited"
-# define USBVENDORID                    0x2DAE
-# define BOOT_DELAY_ADDRESS             0x000001a0
-
-# define BOARD_TYPE                     50
-# define _FLASH_KBYTES                  (*(uint16_t *)0x1ff0f442)
-# define BOARD_FLASH_SECTORS            ((_FLASH_KBYTES == 0x400) ? 7 : 11)
-# define BOARD_FLASH_SIZE               (_FLASH_KBYTES * 1024)
-
-# define OSC_FREQ                       16
-
-# define BOARD_PIN_LED_ACTIVITY         GPIO7 // BLUE
-# define BOARD_PIN_LED_BOOTLOADER       GPIO6 // GREEN
-# define BOARD_PORT_LEDS                GPIOC
-# define BOARD_CLOCK_LEDS               RCC_AHB1ENR_GPIOCEN
-# define BOARD_LED_ON                   gpio_clear
-# define BOARD_LED_OFF                  gpio_set
-
-# define BOARD_USART  					USART2
-# define BOARD_USART_CLOCK_REGISTER 	RCC_APB1ENR
-# define BOARD_USART_CLOCK_BIT      	RCC_APB1ENR_USART2EN
-
-# define BOARD_PORT_USART   			GPIOD
-# define BOARD_PORT_USART_AF 			GPIO_AF7
-# define BOARD_PIN_TX     				GPIO5
-# define BOARD_PIN_RX		     		GPIO6
-# define BOARD_USART_PIN_CLOCK_REGISTER RCC_AHB1ENR
-# define BOARD_USART_PIN_CLOCK_BIT  	RCC_AHB1ENR_GPIODEN
-# define SERIAL_BREAK_DETECT_DISABLED   1
-
-/*
- * Uncommenting this allows to force the bootloader through
- * a PWM output pin. As this can accidentally initialize
- * an ESC prematurely, it is not recommended. This feature
- * has not been used and hence defaults now to off.
- *
- * # define BOARD_FORCE_BL_PIN_OUT         GPIO14
- * # define BOARD_FORCE_BL_PIN_IN          GPIO11
- * # define BOARD_FORCE_BL_PORT            GPIOE
- * # define BOARD_FORCE_BL_CLOCK_REGISTER  RCC_AHB1ENR
- * # define BOARD_FORCE_BL_CLOCK_BIT       RCC_AHB1ENR_IOPEEN
- * # define BOARD_FORCE_BL_PULL            GPIO_PUPD_PULLUP
-*/
-
-/****************************************************************************
  * TARGET_HW_AV_V1
  ****************************************************************************/
 


### PR DESCRIPTION
this is needed as the ArduPilot project has another implementation of
this bootloader protocol, and thus another source of BOARD_TYPE
values. To maintain a common list without collisions this file can be
used