### PR TITLE
Update libopencm3 to upstream master for more legit STM32 F7 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,7 @@ cube_f4_bl: $(MAKEFILE_LIST) $(LIBOPENCM3)
 cube_f7_bl:$(MAKEFILE_LIST) $(LIBOPENCM3)
 	${MAKE} ${MKFLAGS} -f  Makefile.f7 TARGET_HW=CUBE_F7 LINKER_FILE=stm32f7.ld TARGET_FILE_NAME=$@
 
-avxv1_bl:$(MAKEFILE_LIST) $(LIBOPENCM3)
+avx_v1_bl:$(MAKEFILE_LIST) $(LIBOPENCM3)
 	${MAKE} ${MKFLAGS} -f  Makefile.f7 TARGET_HW=AV_X_V1 LINKER_FILE=stm32f7.ld TARGET_FILE_NAME=$@
 
 # Default bootloader delay is *very* short, just long enough to catch

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,8 @@ TARGETS	= \
 	px4iov3_bl \
 	tapv1_bl \
 	cube_f4_bl \
-	cube_f7_bl
+	cube_f7_bl \
+	avx_v1_bl
 
 all:	$(TARGETS) sizes
 
@@ -120,6 +121,9 @@ cube_f4_bl: $(MAKEFILE_LIST) $(LIBOPENCM3)
 
 cube_f7_bl:$(MAKEFILE_LIST) $(LIBOPENCM3)
 	${MAKE} ${MKFLAGS} -f  Makefile.f7 TARGET_HW=CUBE_F7 LINKER_FILE=stm32f7.ld TARGET_FILE_NAME=$@
+
+avxv1_bl:$(MAKEFILE_LIST) $(LIBOPENCM3)
+	${MAKE} ${MKFLAGS} -f  Makefile.f7 TARGET_HW=AV_X_V1 LINKER_FILE=stm32f7.ld TARGET_FILE_NAME=$@
 
 # Default bootloader delay is *very* short, just long enough to catch
 # the board for recovery but not so long as to make restarting after a

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@
 #
 # Paths to common dependencies
 #
+export BUILD_DIR_ROOT ?= build
 export BL_BASE		?= $(wildcard .)
 export LIBOPENCM3	?= $(wildcard libopencm3)
 export LIBKINETIS  	?= $(wildcard lib/kinetis/NXP_Kinetis_Bootloader_2_0_0)

--- a/Makefile.f3
+++ b/Makefile.f3
@@ -20,6 +20,10 @@ FLAGS 		+= -mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16 \
 		   -lopencm3_stm32f3 \
         $(EXTRAFLAGS)
 
+# libopencm3 doesn't have USB driver in stm32f3 library, tell it to use the one from stm32f4
+# for the cdcacm
+$(BUILD_DIR_ROOT)/$(TARGET_FILE_NAME)/stm32/cdcacm.o : FLAGS+=-DSTM32F4
+
 #
 # General rules for making dependency and object files
 # This is where the compiler is called

--- a/Makefile.f7
+++ b/Makefile.f7
@@ -2,7 +2,7 @@
 # PX4 bootloader build rules for STM32F7 targets.
 # Since the STM32F7 is not supported fully in libopencm3 at this time,
 # this build is a bit of a hack to use the similar IP blocks of the F469
-# for RCC and USB by telling libopencm3 it is an STM32F4
+# for USB by telling libopencm3 it is an STM32F4
 ARCH=stm32
 OPENOCD		?= openocd
 
@@ -13,15 +13,17 @@ JTAGCONFIG ?= interface/olimex-jtag-tiny.cfg
 PX4_BOOTLOADER_DELAY	?= 5000
 
 SRCS		 = $(COMMON_SRCS) $(addprefix $(ARCH)/,$(ARCH_SRCS)) main_f7.c
+LIBS			= opencm3_stm32f7 opencm3_stm32f4
 
-FLAGS		+= -g -mthumb -mcpu=cortex-m7 -mfloat-abi=hard -mfpu=fpv5-sp-d16 \
-       -DTARGET_HW_$(TARGET_HW) \
-       -DSTM32F4 \
-       -T$(LINKER_FILE) \
-		   -L$(LIBOPENCM3)/lib \
-		   -lopencm3_stm32f4 \
-        $(EXTRAFLAGS)
+FLAGS			+= -g -mthumb -mcpu=cortex-m7 -mfloat-abi=hard -mfpu=fpv5-sp-d16 \
+				-DTARGET_HW_$(TARGET_HW) \
+				-T$(LINKER_FILE) \
+				-L$(LIBOPENCM3)/lib $(addprefix -l, $(LIBS)) \
+				-DSTM32F7
 
+# libopencm3 doesn't have USB driver in stm32f7 library, tell it to use the one from stm32f4
+# for the cdcacm
+$(BUILD_DIR_ROOT)/$(TARGET_FILE_NAME)/stm32/cdcacm.o : FLAGS+=-DSTM32F4
 #
 # General rules for making dependency and object files
 # This is where the compiler is called

--- a/hw_config.h
+++ b/hw_config.h
@@ -1006,16 +1006,16 @@
 
 # define OSC_FREQ                       16
 
-# define BOARD_USART  			UART8
-# define BOARD_USART_CLOCK_REGISTER 	RCC_APB1ENR
-# define BOARD_USART_CLOCK_BIT      	RCC_APB1ENR_UART8EN
+# define BOARD_USART                    UART8
+# define BOARD_USART_CLOCK_REGISTER     RCC_APB1ENR
+# define BOARD_USART_CLOCK_BIT          RCC_APB1ENR_UART8EN
 
-# define BOARD_PORT_USART   		GPIOE
-# define BOARD_PORT_USART_AF 		GPIO_AF7
-# define BOARD_PIN_TX     		GPIO1
-# define BOARD_PIN_RX		     	GPIO0
+# define BOARD_PORT_USART               GPIOE
+# define BOARD_PORT_USART_AF            GPIO_AF7
+# define BOARD_PIN_TX                   GPIO1
+# define BOARD_PIN_RX                   GPIO0
 # define BOARD_USART_PIN_CLOCK_REGISTER RCC_AHB1ENR
-# define BOARD_USART_PIN_CLOCK_BIT  	RCC_AHB1ENR_IOPDEN
+# define BOARD_USART_PIN_CLOCK_BIT      RCC_AHB1ENR_GPIODEN
 # define SERIAL_BREAK_DETECT_DISABLED   1
 
 #else

--- a/hw_config.h
+++ b/hw_config.h
@@ -987,6 +987,37 @@
  * # define BOARD_FORCE_BL_PULL            GPIO_PUPD_PULLUP
 */
 
+/****************************************************************************
+ * TARGET_HW_AV_V1
+ ****************************************************************************/
+
+#elif  defined(TARGET_HW_AV_X_V1)
+
+# define APP_LOAD_ADDRESS               0x08008000
+# define BOOTLOADER_DELAY               5000
+# define INTERFACE_USB                  0
+# define INTERFACE_USART                1
+# define BOOT_DELAY_ADDRESS             0x000001a0
+
+# define BOARD_TYPE                     29
+# define _FLASH_KBYTES                  (*(uint16_t *)0x1ff0f442)
+# define BOARD_FLASH_SECTORS            ((_FLASH_KBYTES == 0x400) ? 7 : 11)
+# define BOARD_FLASH_SIZE               (_FLASH_KBYTES * 1024)
+
+# define OSC_FREQ                       16
+
+# define BOARD_USART  			UART8
+# define BOARD_USART_CLOCK_REGISTER 	RCC_APB1ENR
+# define BOARD_USART_CLOCK_BIT      	RCC_APB1ENR_UART8EN
+
+# define BOARD_PORT_USART   		GPIOE
+# define BOARD_PORT_USART_AF 		GPIO_AF7
+# define BOARD_PIN_TX     		GPIO1
+# define BOARD_PIN_RX		     	GPIO0
+# define BOARD_USART_PIN_CLOCK_REGISTER RCC_AHB1ENR
+# define BOARD_USART_PIN_CLOCK_BIT  	RCC_AHB1ENR_IOPDEN
+# define SERIAL_BREAK_DETECT_DISABLED   1
+
 #else
 # error Undefined Target Hardware
 #endif

--- a/hw_config.h
+++ b/hw_config.h
@@ -30,8 +30,7 @@
  * USBPRODUCTID         0x0011                - PID Should match defconfig
  * BOOT_DELAY_ADDRESS   0x000001a0            - (Optional) From the linker script from Linker Script to get a custom
  *                                               delay provided by an APP FW
-
-*  BOARD_TYPE           9                     - Must match .prototype boad_id
+ * BOARD_TYPE           9                     - Must match .prototype boad_id
  * _FLASH_KBYTES        (*(uint16_t *)0x1fff7a22) - Run time flash size detection
  * BOARD_FLASH_SECTORS  ((_FLASH_KBYTES == 0x400) ? 11 : 23) - Run time determine the physical last sector
  * BOARD_FLASH_SECTORS   11                   - Hard coded zero based last sector
@@ -349,7 +348,7 @@
 # define BOARD_PIN_LED_ACTIVITY         GPIO7 // BLUE
 # define BOARD_PIN_LED_BOOTLOADER       GPIO6 // GREEN
 # define BOARD_PORT_LEDS                GPIOC
-# define BOARD_CLOCK_LEDS               RCC_AHB1ENR_IOPCEN
+# define BOARD_CLOCK_LEDS               RCC_AHB1ENR_GPIOCEN
 # define BOARD_LED_ON                   gpio_clear
 # define BOARD_LED_OFF                  gpio_set
 
@@ -362,7 +361,7 @@
 # define BOARD_PIN_TX     				GPIO5
 # define BOARD_PIN_RX		     		GPIO6
 # define BOARD_USART_PIN_CLOCK_REGISTER RCC_AHB1ENR
-# define BOARD_USART_PIN_CLOCK_BIT  	RCC_AHB1ENR_IOPDEN
+# define BOARD_USART_PIN_CLOCK_BIT  	RCC_AHB1ENR_GPIODEN
 # define SERIAL_BREAK_DETECT_DISABLED   1
 
 /*
@@ -853,7 +852,7 @@
 # define FLASH_SECTOR_SIZE              4096
 # define BOARD_FLASH_SIZE               (_FLASH_KBYTES * 1024)
 # define BOARD_FLASH_SECTORS            ((BOARD_FLASH_SIZE / FLASH_SECTOR_SIZE)- \
-                                         (BOOTLOADER_RESERVATION_SIZE/FLASH_SECTOR_SIZE))
+		(BOOTLOADER_RESERVATION_SIZE/FLASH_SECTOR_SIZE))
 
 # define OSC_FREQ                       16
 
@@ -958,7 +957,7 @@
 # define BOARD_PIN_LED_ACTIVITY         GPIO7 // BLUE
 # define BOARD_PIN_LED_BOOTLOADER       GPIO6 // GREEN
 # define BOARD_PORT_LEDS                GPIOC
-# define BOARD_CLOCK_LEDS               RCC_AHB1ENR_IOPCEN
+# define BOARD_CLOCK_LEDS               RCC_AHB1ENR_GPIOCEN
 # define BOARD_LED_ON                   gpio_clear
 # define BOARD_LED_OFF                  gpio_set
 
@@ -971,7 +970,7 @@
 # define BOARD_PIN_TX     				GPIO5
 # define BOARD_PIN_RX		     		GPIO6
 # define BOARD_USART_PIN_CLOCK_REGISTER RCC_AHB1ENR
-# define BOARD_USART_PIN_CLOCK_BIT  	RCC_AHB1ENR_IOPDEN
+# define BOARD_USART_PIN_CLOCK_BIT  	RCC_AHB1ENR_GPIODEN
 # define SERIAL_BREAK_DETECT_DISABLED   1
 
 /*

--- a/main_f3.c
+++ b/main_f3.c
@@ -29,13 +29,13 @@
 # define BOARD_INTERFACE_CONFIG		NULL
 #endif
 const struct rcc_clock_scale _rcc_hsi_8mhz = {
-
-	.pll = RCC_CFGR_PLLMUL_PLL_IN_CLK_X16,
 	.pllsrc = RCC_CFGR_PLLSRC_HSI_DIV2,
+	.pllmul = RCC_CFGR_PLLMUL_MUL16,
+	.plldiv = RCC_CFGR2_PREDIV_NODIV,
 	.hpre = RCC_CFGR_HPRE_DIV_NONE,
 	.ppre1 = RCC_CFGR_PPRE1_DIV_2,
 	.ppre2 = RCC_CFGR_PPRE2_DIV_NONE,
-	.flash_config = FLASH_ACR_PRFTBE | FLASH_ACR_LATENCY_2WS,
+	.flash_waitstates = 2,
 	.ahb_frequency	= 64000000,
 	.apb1_frequency = 32000000,
 	.apb2_frequency = 64000000,

--- a/main_f4.c
+++ b/main_f4.c
@@ -177,7 +177,7 @@ static const struct rcc_clock_scale clock_setup = {
 	.ppre1 = RCC_CFGR_PPRE_DIV_4,
 	.ppre2 = RCC_CFGR_PPRE_DIV_2,
 	.power_save = 0,
-	.flash_config = FLASH_ACR_ICE | FLASH_ACR_DCE | FLASH_ACR_LATENCY_5WS,
+	.flash_config = FLASH_ACR_ICEN | FLASH_ACR_DCEN | FLASH_ACR_LATENCY_5WS,
 	.apb1_frequency = 42000000,
 	.apb2_frequency = 84000000,
 };

--- a/main_f7.c
+++ b/main_f7.c
@@ -145,7 +145,7 @@ static const struct rcc_clock_scale clock_setup = {
 	.ppre1 = RCC_CFGR_PPRE_DIV_4,
 	.ppre2 = RCC_CFGR_PPRE_DIV_2,
 	.power_save = 0,
-	.flash_config = FLASH_ACR_ICE | FLASH_ACR_DCE | FLASH_ACR_LATENCY_5WS,
+	.flash_config = FLASH_ACR_ICEN | FLASH_ACR_DCEN | FLASH_ACR_LATENCY_5WS,
 	.apb1_frequency = 54000000,
 	.apb2_frequency = 108000000,
 };

--- a/main_f7.c
+++ b/main_f7.c
@@ -17,6 +17,16 @@
 #include "bl.h"
 #include "uart.h"
 
+#if !defined(USART6)
+#  define USART6    USART6_BASE
+#endif
+#if !defined(UART6)
+#  define UART7    UART7_BASE
+#endif
+#if !defined(USART8)
+#  define UART8    UART8_BASE
+#endif
+
 /* flash parameters that we should not really know */
 static struct {
 	uint32_t	sector_number;

--- a/main_f7.c
+++ b/main_f7.c
@@ -366,6 +366,7 @@ board_init(void)
 	gpio_mode_setup(BOARD_FORCE_BL_PORT, GPIO_MODE_INPUT, BOARD_FORCE_BL_PULL, BOARD_FORCE_BL_PIN);
 #endif
 
+#if defined(BOARD_CLOCK_LEDS)
 	/* initialise LEDs */
 	rcc_peripheral_enable_clock(&RCC_AHB1ENR, BOARD_CLOCK_LEDS);
 	gpio_mode_setup(
@@ -381,7 +382,7 @@ board_init(void)
 	BOARD_LED_ON(
 		BOARD_PORT_LEDS,
 		BOARD_PIN_LED_BOOTLOADER | BOARD_PIN_LED_ACTIVITY);
-
+#endif
 	/* enable the power controller clock */
 	rcc_peripheral_enable_clock(&RCC_APB1ENR, RCC_APB1ENR_PWREN);
 }
@@ -417,12 +418,14 @@ board_deinit(void)
 	gpio_mode_setup(BOARD_POWER_PORT, GPIO_MODE_INPUT, GPIO_PUPD_NONE, BOARD_POWER_PIN);
 #endif
 
+#if defined(BOARD_CLOCK_LEDS)
 	/* deinitialise LEDs */
 	gpio_mode_setup(
 		BOARD_PORT_LEDS,
 		GPIO_MODE_INPUT,
 		GPIO_PUPD_NONE,
 		BOARD_PIN_LED_BOOTLOADER | BOARD_PIN_LED_ACTIVITY);
+#endif
 
 	/* disable the power controller clock */
 	rcc_peripheral_disable_clock(&RCC_APB1ENR, RCC_APB1ENR_PWREN);
@@ -642,11 +645,15 @@ led_on(unsigned led)
 {
 	switch (led) {
 	case LED_ACTIVITY:
+#if defined(BOARD_PIN_LED_ACTIVITY)
 		BOARD_LED_ON(BOARD_PORT_LEDS, BOARD_PIN_LED_ACTIVITY);
+#endif
 		break;
 
 	case LED_BOOTLOADER:
+#if defined(BOARD_PIN_LED_BOOTLOADER)
 		BOARD_LED_ON(BOARD_PORT_LEDS, BOARD_PIN_LED_BOOTLOADER);
+#endif
 		break;
 	}
 }
@@ -656,11 +663,15 @@ led_off(unsigned led)
 {
 	switch (led) {
 	case LED_ACTIVITY:
+#if defined(BOARD_PIN_LED_ACTIVITY)
 		BOARD_LED_OFF(BOARD_PORT_LEDS, BOARD_PIN_LED_ACTIVITY);
+#endif
 		break;
 
 	case LED_BOOTLOADER:
+#if defined(BOARD_PIN_LED_BOOTLOADER)
 		BOARD_LED_OFF(BOARD_PORT_LEDS, BOARD_PIN_LED_BOOTLOADER);
+#endif
 		break;
 	}
 }
@@ -670,11 +681,15 @@ led_toggle(unsigned led)
 {
 	switch (led) {
 	case LED_ACTIVITY:
+#if defined(BOARD_PIN_LED_ACTIVITY)
 		gpio_toggle(BOARD_PORT_LEDS, BOARD_PIN_LED_ACTIVITY);
+#endif
 		break;
 
 	case LED_BOOTLOADER:
+#if defined(BOARD_PIN_LED_BOOTLOADER)
 		gpio_toggle(BOARD_PORT_LEDS, BOARD_PIN_LED_BOOTLOADER);
+#endif
 		break;
 	}
 }

--- a/main_f7.c
+++ b/main_f7.c
@@ -142,11 +142,10 @@ static void board_init(void);
  */
 static const struct rcc_clock_scale clock_setup = {
 	/* 216MHz */
-	.pllm = OSC_FREQ,
 	.plln = 432,
 	.pllp = 2,
 	.pllq = 9,
-	.flash_config = FLASH_ACR_ICEN | FLASH_ACR_DCEN | FLASH_ACR_LATENCY_7WS,
+	.flash_waitstates = 7,
 	.hpre = RCC_CFGR_HPRE_DIV_NONE,
 	.ppre1 = RCC_CFGR_PPRE_DIV_4,
 	.ppre2 = RCC_CFGR_PPRE_DIV_2,
@@ -300,6 +299,7 @@ board_test_usart_receiving_break()
 	if (cnt_consecutive_low >= 18) {
 		return true;
 	}
+
 #endif // !defined(SERIAL_BREAK_DETECT_DISABLED)
 
 	return false;
@@ -429,7 +429,7 @@ board_deinit(void)
 static inline void
 clock_init(void)
 {
-	rcc_clock_setup_hse_3v3(&clock_setup);
+	rcc_clock_setup_hse(&clock_setup, OSC_FREQ);
 }
 
 /**

--- a/rules.mk
+++ b/rules.mk
@@ -2,7 +2,7 @@
 # Common rules for makefiles for the PX4 bootloaders
 #
 
-BUILD_DIR	 = build/$(TARGET_FILE_NAME)
+BUILD_DIR	 = $(BUILD_DIR_ROOT)/$(TARGET_FILE_NAME)
 
 COBJS		:= $(addprefix $(BUILD_DIR)/, $(patsubst %.c,%.o,$(SRCS)))
 AOBJS		:= $(addprefix $(BUILD_DIR)/, $(patsubst %.S,%.o,$(ASRCS)))
@@ -16,17 +16,17 @@ BINARY		 = $(BUILD_DIR)/$(TARGET_FILE_NAME).bin
 all:	debug $(BUILD_DIR) $(ELF) $(BINARY)
 
 debug:
-	@echo SRCS=$(SRCS)
-	@echo COBJS=$(COBJS)
-	@echo ASRCS=$(ASRCS)
-	@echo AOBJS=$(AOBJS)
-	@echo SUBDIRS=$(SUBDIRS)
+#	@echo SRCS=$(SRCS)
+#	@echo COBJS=$(COBJS)
+#	@echo ASRCS=$(ASRCS)
+#	@echo AOBJS=$(AOBJS)
+#	@echo SUBDIRS=$(SUBDIRS)
 
 
 # Compile and generate dependency files
 $(BUILD_DIR)/%.o:	%.c
 	@echo Generating object $@
-	$(CC) -c -MMD $(FLAGS) -o $@ $*.c
+	$(CC) -c -MMD $(FLAGS) -o $@ $<
 
 $(BUILD_DIR)/%.o:	%.S
 	@echo Generating object $@

--- a/stm32/cdcacm.c
+++ b/stm32/cdcacm.c
@@ -36,7 +36,7 @@
 #include <libopencm3/stm32/rcc.h>
 #include <libopencm3/stm32/gpio.h>
 #include <libopencm3/stm32/flash.h>
-#include <libopencm3/stm32/otg_fs.h>
+#include <libopencm3/usb/dwc/otg_fs.h>
 
 #include <libopencm3/cm3/systick.h>
 #include <libopencm3/cm3/nvic.h>
@@ -218,9 +218,9 @@ static const struct usb_cdc_line_coding line_coding = {
 	.bParityType = USB_CDC_NO_PARITY,
 	.bDataBits = 0x08
 };
-
-static int cdcacm_control_request(usbd_device *usbd_dev, struct usb_setup_data *req, uint8_t **buf,
-				  uint16_t *len, void (**complete)(usbd_device *usbd_dev, struct usb_setup_data *req))
+static enum usbd_request_return_codes cdcacm_control_request(usbd_device *usbd_dev, struct usb_setup_data *req,
+		uint8_t **buf,
+		uint16_t *len, usbd_control_complete_callback *complete)
 {
 	(void)complete;
 	(void)buf;

--- a/stm32/usart.c
+++ b/stm32/usart.c
@@ -89,7 +89,7 @@ uart_cin(void)
 {
 	int c = -1;
 
-	if (USART_SR(usart) & USART_SR_RXNE) {
+	if (USART_SR(usart) & USART_FLAG_RXNE) {
 		c = usart_recv(usart);
 	}
 


### PR DESCRIPTION
@LorenzMeier @DanielePettenuzzo 

This PR updates the libopencm3 to upstream master for more legit STM32 F7 support.

The uart is now supported, as is the real RCC. USB is still a hack using the F4 driver.

**This need complete testing on ALL hw platforms before it is merged. At lease on F1, F3, and F4 platform should be tested.**

I have tested both serial and USB on FMUv5.

I was getting timeout on the CRC calculation returning results.

```
chip: 10016451
family: STM32F7[6|7]x
revision: Z
flash 2064384

Erase  : [====================] 100.0%
Program: [====================] 100.0%
Verify : [                    ] 1.0%
ERROR: timeout waiting for data (4 bytes)

```
This fixes it. YMMV

```
diff --git a/Tools/px_uploader.py b/Tools/px_uploader.py
index a0cec1f..2ef7959 100755
--- a/Tools/px_uploader.py
+++ b/Tools/px_uploader.py
@@ -448,6 +448,7 @@ class uploader(object):
         expect_crc = fw.crc(self.fw_maxsize)
         self.__send(uploader.GET_CRC +
                     uploader.EOC)
+        time.sleep(1.0)
         report_crc = self.__recv_int()
         self.__getSync()
         if report_crc != expect_crc:

```