### PR TITLE
omnibusf4sd: reserve the first sector of the firmware for flash-based params storage

### DIFF
--- a/hw_config.h
+++ b/hw_config.h
@@ -702,7 +702,7 @@
 
 #elif  defined(TARGET_HW_OMNIBUSF4SD)
 
-# define APP_LOAD_ADDRESS               0x08004000
+# define APP_LOAD_ADDRESS               0x08008000
 # define BOOTLOADER_DELAY               5000
 # define BOARD_OMNIBUSF4SD
 # define INTERFACE_USB                  1
@@ -713,6 +713,8 @@
 # define BOARD_TYPE                     42
 # define BOARD_FLASH_SECTORS            11
 # define BOARD_FLASH_SIZE               (1024 * 1024)
+# define BOARD_FIRST_FLASH_SECTOR_TO_ERASE	1
+# define APP_RESERVATION_SIZE			(1 * 16 * 1024) /* 1 16 Kib Sectors */
 
 # define OSC_FREQ                       8
 


### PR DESCRIPTION
It removes the SD card dependency as some omnibus boards do not have one.

This is a **breaking** change and requires the Firmware to update as well.
The alternative would be to add a separate bootloader target, but going forward I think this is simpler and removes the SD card dependency even on boards that have one.

I only used 1 sector of 16KB, as I think it will be enough (a typical params file is around 4KB). We have the option of adding another 16KB sector if needed (the Intel Aero uses 2).