### PR TITLE
make: add .hex binary output to build target

### DIFF
--- a/rules.mk
+++ b/rules.mk
@@ -11,9 +11,10 @@ OBJS		:= $(COBJS) $(AOBJS)
 DEPS		:= $(COBJS:.o=.d)
 
 ELF		 = $(BUILD_DIR)/$(TARGET_FILE_NAME).elf
+HEX		 = $(BUILD_DIR)/$(TARGET_FILE_NAME).hex
 BINARY		 = $(BUILD_DIR)/$(TARGET_FILE_NAME).bin
 
-all:	debug $(BUILD_DIR) $(ELF) $(BINARY)
+all:	debug $(BUILD_DIR) $(ELF) $(BINARY) $(HEX)
 
 debug:
 #	@echo SRCS=$(SRCS)
@@ -41,6 +42,9 @@ $(ELF):		$(OBJS) $(MAKEFILE_LIST)
 
 $(BINARY):	$(ELF)
 	$(OBJCOPY) -O binary $(ELF) $(BINARY)
+
+$(HEX):	$(ELF)
+	$(OBJCOPY) -Oihex $(ELF) $(HEX)
 
 # Dependencies for .o files
 -include $(DEPS)


### PR DESCRIPTION
This is useful for flashing boards like the Omnibus via Betaflight
Configurator that come preflashed with Betaflight.

It is built with the default target, we can make a separate target if we don't want that.

@dagar do we build & push the binaries somewhere already?