### PR TITLE
added IDs for two H743 based boards

### DIFF
--- a/board_types.txt
+++ b/board_types.txt
@@ -47,4 +47,6 @@ AP_HW_F35LIGHTNING                    135
 AP_HW_MRO_X2V1_777                    136
 AP_HW_OMNIBUSF4V6                     137
 AP_HW_HELIOSPRING                     138
+AP_HW_PIXHAWK4PRO                     139
+AP_HW_CUBEORANGE                      140
 AP_HW_F4BY                             20 # value due to previous release by vendor


### PR DESCRIPTION
one is the Pixhawk4Pro from Holybro, the other the CubeOrange from Hex