### PR TITLE
KakuteF7 board support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.d
 *.elf
 *.bin
+*.hex
 Bootloader.zip
 Bootloader.sublime-workspace
 .gdbinit

--- a/Makefile
+++ b/Makefile
@@ -53,10 +53,13 @@ export ARCH_SRCS	 = cdcacm.c  usart.c
 # string
 #
 TARGETS	= \
-	fmuk66v3_bl \
 	aerofcv1_bl \
 	auavx2v1_bl \
+	avx_v1_bl \
 	crazyflie_bl \
+	cube_f4_bl \
+	fmuk66v3_bl \
+	kakutef7_bl \
 	mindpxv2_bl \
 	omnibusf4sd_bl \
 	px4aerocore_bl \
@@ -70,9 +73,7 @@ TARGETS	= \
 	px4fmuv5_bl \
 	px4io_bl \
 	px4iov3_bl \
-	tapv1_bl \
-	cube_f4_bl \
-	avx_v1_bl
+	tapv1_bl
 
 all:	$(TARGETS) sizes
 
@@ -90,6 +91,9 @@ fmuk66v3_bl: $(MAKEFILE_LIST) $(LIBKINETIS)
 
 auavx2v1_bl: $(MAKEFILE_LIST) $(LIBOPENCM3)
 	${MAKE} ${MKFLAGS} -f  Makefile.f4 TARGET_HW=AUAV_X2V1  LINKER_FILE=stm32f4.ld TARGET_FILE_NAME=$@
+
+kakutef7_bl: $(MAKEFILE_LIST) $(LIBOPENCM3)
+	${MAKE} ${MKFLAGS} -f  Makefile.f7 TARGET_HW=KAKUTEF7 LINKER_FILE=stm32f7.ld TARGET_FILE_NAME=$@
 
 px4fmu_bl: $(MAKEFILE_LIST) $(LIBOPENCM3)
 	${MAKE} ${MKFLAGS} -f  Makefile.f4 TARGET_HW=PX4_FMU_V1 LINKER_FILE=stm32f4.ld TARGET_FILE_NAME=$@

--- a/bl.c
+++ b/bl.c
@@ -633,7 +633,7 @@ bootloader(unsigned timeout)
 				flash_func_erase_sector(i);
 			}
 
-			// enable the LED while verifying the erase
+			// disable the LED while verifying the erase
 			led_set(LED_OFF);
 
 			// verify the erase

--- a/board_types.txt
+++ b/board_types.txt
@@ -24,6 +24,7 @@ TARGET_HW_AUAV_X2V1                    33
 TARGET_HW_AEROFC_V1                    65
 TARGET_HW_CUBE_F4                       9
 TARGET_HW_AV_V1                        29
+TARGET_HW_KAKUTEF7                    123
 
 # values from external vendors
 EXT_HW_RADIOLINK_MINI_PIX               3
@@ -35,7 +36,6 @@ EXT_HW_RADIOLINK_MINI_PIX               3
 AP_HW_CUBE_ORANGE                     120
 AP_HW_OMNIBUSF7V2                     121
 AP_HW_KAKUTEF4                        122
-AP_HW_KAKUTEF7                        123
 AP_HW_REVOLUTION                      124
 AP_HW_MATEKF405                       125
 AP_HW_NUCLEOF767ZI                    126

--- a/hw_config.h
+++ b/hw_config.h
@@ -710,7 +710,6 @@
 
 # define APP_LOAD_ADDRESS               0x08008000
 # define BOOTLOADER_DELAY               5000
-# define BOARD_OMNIBUSF4SD
 # define INTERFACE_USB                  1
 # define INTERFACE_USART                0
 # define USBDEVICESTRING                "PX4 OmnibusF4SD"
@@ -732,10 +731,55 @@
 # define BOARD_LED_OFF                  gpio_set
 
 # define BOARD_USB_VBUS_SENSE_DISABLED
-//# define BOARD_PIN_VBUS                 GPIO5
-//# define BOARD_PORT_VBUS                GPIOC
 
 # define USBMFGSTRING                   "Vertile"
+
+/****************************************************************************
+ * TARGET_HW_KAKUTEF7
+ ****************************************************************************/
+
+#elif  defined(TARGET_HW_KAKUTEF7)
+
+# define APP_LOAD_ADDRESS               0x08018000
+# define BOOTLOADER_DELAY               5000
+# define INTERFACE_USB                  1
+# define INTERFACE_USART                0
+# define USBDEVICESTRING                "PX4 KakuteF7"
+# define USBPRODUCTID                   0x0016
+# define BOOT_DELAY_ADDRESS             0x000001a0
+
+# define BOARD_TYPE                     123
+# define BOARD_FLASH_SECTORS            7
+# define BOARD_FLASH_SIZE               (1024 * 1024)
+# define BOARD_FIRST_FLASH_SECTOR_TO_ERASE	2
+# define APP_RESERVATION_SIZE			(2 * 32 * 1024) /* 2 32 Kib Sectors */
+
+# define OSC_FREQ                       8
+
+# define BOARD_PIN_LED_ACTIVITY         0
+# define BOARD_PIN_LED_BOOTLOADER       GPIO2 // BLUE
+# define BOARD_PORT_LEDS                GPIOA
+# define BOARD_CLOCK_LEDS               RCC_AHB1ENR_GPIOAEN
+# define BOARD_LED_ON                   gpio_clear
+# define BOARD_LED_OFF                  gpio_set
+
+# define USBMFGSTRING                   "Holybro"
+
+// VBUS sense is connected to PA8 instead of PA9
+# define BOARD_USB_VBUS_SENSE_DISABLED
+# define BOARD_PORT_VBUS                GPIOA
+# define BOARD_PIN_VBUS                 GPIO8
+
+# define BOARD_USART  					USART3 // labeled as UART3
+# define BOARD_USART_CLOCK_REGISTER     RCC_APB1ENR
+# define BOARD_USART_CLOCK_BIT          RCC_APB1ENR_USART3EN
+# define BOARD_PORT_USART               GPIOB
+# define BOARD_PORT_USART_AF            GPIO_AF7
+# define BOARD_PIN_TX                   GPIO10
+# define BOARD_PIN_RX                   GPIO11
+# define BOARD_USART_PIN_CLOCK_REGISTER RCC_AHB1ENR
+# define BOARD_USART_PIN_CLOCK_BIT      RCC_AHB1ENR_GPIOBEN
+# define SERIAL_BREAK_DETECT_DISABLED   1
 
 /****************************************************************************
  * TARGET_HW_AUAV_X2V1

--- a/main_f7.c
+++ b/main_f7.c
@@ -27,6 +27,14 @@
 #  define UART8    UART8_BASE
 #endif
 
+// A board may disable VBUS sensing, but still provide a (non-standard) VBUS
+// sensing pin (and use it for fast booting when USB is disconnected). If VBUS
+// sensing is enabled, only PA9 can be used.
+#ifndef BOARD_USB_VBUS_SENSE_DISABLED
+# define BOARD_PORT_VBUS                GPIOA
+# define BOARD_PIN_VBUS                 GPIO9
+#endif
+
 /* flash parameters that we should not really know */
 static struct {
 	uint32_t	sector_number;
@@ -146,9 +154,9 @@ static void board_init(void);
 
 /* standard clocking for all F7 boards: 216MHz w/ overdrive
  *
- * f_voc = f_osc * (PLLN / PLLM) = OSC_FREQ * PLLN / OSC_FREQ = PLLN = 432
- * f_pll = f_voc / PLLP = PLLN / PLLP = 216
- * f_usb_sdmmc = f_voc / PLLQ = 48
+ * f_vco = f_osc * (PLLN / PLLM) = OSC_FREQ * PLLN / OSC_FREQ = PLLN = 432
+ * f_pll = f_vco / PLLP = PLLN / PLLP = 216
+ * f_usb_sdmmc = f_vco / PLLQ = 48
  */
 static const struct rcc_clock_scale clock_setup = {
 	/* 216MHz */
@@ -346,11 +354,10 @@ board_init(void)
 #endif
 
 #if INTERFACE_USB
-	/* enable Port A GPIO9 to sample VBUS */
+#if !defined(BOARD_USB_VBUS_SENSE_DISABLED)
+	/* enable configured GPIO to sample VBUS */
 	rcc_peripheral_enable_clock(&RCC_AHB1ENR, RCC_AHB1ENR_GPIOAEN);
-#  if defined(USE_VBUS_PULL_DOWN)
-	gpio_mode_setup(GPIOA, GPIO_MODE_INPUT, GPIO_PUPD_PULLDOWN, GPIO9);
-#  endif
+#endif
 #endif
 
 #if INTERFACE_USART
@@ -812,15 +819,16 @@ main(void)
 	 * If the force-bootloader pins are tied, we will stay here until they are removed and
 	 * we then time out.
 	 */
-#if defined(BOARD_USB_VBUS_SENSE_DISABLED)
-	try_boot = false;
-#else
+#if defined(BOARD_PORT_VBUS)
 
-	if (gpio_get(GPIOA, GPIO9) != 0) {
+	if (gpio_get(BOARD_PORT_VBUS, BOARD_PIN_VBUS) != 0) {
 		usb_connected = true;
 		/* don't try booting before we set up the bootloader */
 		try_boot = false;
 	}
+
+#else
+	try_boot = false;
 
 #endif
 #endif

--- a/stm32/cdcacm.c
+++ b/stm32/cdcacm.c
@@ -47,6 +47,13 @@
 #if INTERFACE_USB != 0
 #define USB_CDC_REQ_GET_LINE_CODING			0x21 // Not defined in libopencm3
 
+#ifndef OTG_GOTGCTL_BVALOVAL
+#define OTG_GOTGCTL_BVALOVAL   (1 << 7)
+#endif
+#ifndef OTG_GOTGCTL_BVALOEN
+#define OTG_GOTGCTL_BVALOEN    (1 << 6)
+#endif
+
 /*
  * ST changed the meaning and sense of a few critical bits
  * in the USB IP block identified as 0x00002000
@@ -56,6 +63,11 @@
  */
 #define OTG_CID_HAS_VBDEN 0x00002000
 #define OTG_GCCFG_VBDEN   (1 << 21)
+/*
+ * The B-peripheral session valid override (BVALOVAL and BVALOEN) bits got added
+ * in OTG FS CID 0x00002000
+ */
+#define OTG_CID_HAS_BVALOVAL 0x00002000
 
 /* Provide the stings for the Index 1-n as a requested index of 0 is used for the supported langages
  *  and is hard coded in the usb lib. The array below is indexed by requested index-1, therefore
@@ -316,6 +328,12 @@ usb_cinit(void)
 
 #if defined(BOARD_USB_VBUS_SENSE_DISABLED)
 	OTG_FS_GCCFG |= OTG_GCCFG_NOVBUSSENS;
+
+	if (OTG_FS_CID == OTG_CID_HAS_BVALOVAL) {
+		/* Force valid B-peripheral session */
+		OTG_FS_GOTGCTL |= OTG_GOTGCTL_BVALOEN | OTG_GOTGCTL_BVALOVAL;
+	}
+
 #endif
 
 	usbd_dev = usbd_init(&otgfs_usb_driver, &dev, &config, usb_strings, NUM_USB_STRINGS,

--- a/stm32/cdcacm.c
+++ b/stm32/cdcacm.c
@@ -75,7 +75,7 @@ static uint8_t usbd_control_buffer[128];
 
 static const struct usb_device_descriptor dev = {
 	.bLength = USB_DT_DEVICE_SIZE,
-	.bDescriptorType = USB_DT_DEVICE,	/**< Specifies he descriptor type */
+	.bDescriptorType = USB_DT_DEVICE,	/**< Specifies the descriptor type */
 	.bcdUSB = 0x0200,					/**< The USB interface version, binary coded (2.0) */
 	.bDeviceClass = USB_CLASS_CDC,		/**< USB device class, CDC in this case */
 	.bDeviceSubClass = 0,


### PR DESCRIPTION
This adds support for the Holybro KakuteF7 board.

There are 2*32KB sectors reserved for parameters - I used 2 to stay compatible with ArduPilot's configuration.

### VBUS sensing
Looking through the datasheet, only PA9 can be used for VBUS sensing. If another pin is assigned (which is the case for KakuteF7), we can still use it for fast-boot detection. I did some changes to account for that in general. In case of disabled VBUS sensing, we need to force valid B-peripheral session, otherwise the USB device will not show up.
I think we could generally just disable VBUS sensing (but still use the pin for fast-boot detection). On the Firmware/NuttX we have it disabled as well.

The only other boards affected by this are OmnibusF4SD and Crazyflie. I cross-tested on Omnibus.