### PR TITLE
Add support for ModalAI FMU v5m

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,7 +29,8 @@ pipeline {
                      "px4fmuv4pro_bl",
                      "px4fmuv5_bl",
                      "px4io_bl",
-                     "smartap_pro_bl"
+                     "smartap_pro_bl",
+                     "modalai_fmuv5m_bl"
             ],
             image: docker_images.nuttx,
             archive: true

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,8 @@ TARGETS	= \
 	px4io_bl \
 	px4iov3_bl \
 	tapv1_bl \
-	smartap_pro_bl
+	smartap_pro_bl \
+	modalai_fmuv5m_bl
 
 all:	$(TARGETS) sizes
 
@@ -143,6 +144,9 @@ avx_v1_bl:$(MAKEFILE_LIST) $(LIBOPENCM3)
 
 smartap_pro_bl:$(MAKEFILE_LIST) $(LIBOPENCM3)
 	${MAKE} ${MKFLAGS} -f  Makefile.f7 TARGET_HW=SMARTAP_PRO LINKER_FILE=stm32f7.ld TARGET_FILE_NAME=$@
+
+modalai_fmuv5m_bl:$(MAKEFILE_LIST) $(LIBOPENCM3)
+	${MAKE} ${MKFLAGS} -f  Makefile.f7 TARGET_HW=MODALAI_FMUV5M LINKER_FILE=stm32f7.ld TARGET_FILE_NAME=$@
 
 # Default bootloader delay is *very* short, just long enough to catch
 # the board for recovery but not so long as to make restarting after a

--- a/board_types.txt
+++ b/board_types.txt
@@ -26,6 +26,7 @@ TARGET_HW_CUBE_F4                       9
 TARGET_HW_AV_V1                        29
 TARGET_HW_KAKUTEF7                    123
 TARGET_HW_SMARTAP_PRO                  32
+TARGET_HW_MODALAI_FMUV5M            41775
 
 # values from external vendors
 EXT_HW_RADIOLINK_MINI_PIX               3

--- a/hw_config.h
+++ b/hw_config.h
@@ -1047,6 +1047,35 @@
 # define BOARD_LED_ON                   gpio_set
 # define BOARD_LED_OFF                  gpio_clear
 
+/****************************************************************************
+ * TARGET_HW_MODALAI_FMUV5M
+ ****************************************************************************/
+
+#elif  defined(TARGET_HW_MODALAI_FMUV5M)
+
+# define APP_LOAD_ADDRESS               0x08008000
+# define BOOTLOADER_DELAY               5000
+# define INTERFACE_USB                  1
+# define INTERFACE_USART                0
+# define USBDEVICESTRING                "PX4 BL FMU v5m.x"
+# define USBMFGSTRING                   "ModalAI"
+# define USBPRODUCTID                   0xa32f
+# define USBVENDORID                    0x0483
+# define BOOT_DELAY_ADDRESS             0x000001a0
+
+# define BOARD_TYPE                     41775
+# define _FLASH_KBYTES                  (*(uint16_t *)0x1ff0f442)
+# define BOARD_FLASH_SECTORS            ((_FLASH_KBYTES == 0x400) ? 7 : 11)
+# define BOARD_FLASH_SIZE               (_FLASH_KBYTES * 1024)
+
+# define OSC_FREQ                       16
+
+# define BOARD_PIN_LED_ACTIVITY         GPIO0 // RED
+# define BOARD_PIN_LED_BOOTLOADER       GPIO1 // GREEN
+# define BOARD_PORT_LEDS                GPIOB
+# define BOARD_CLOCK_LEDS               RCC_AHB1ENR_GPIOBEN
+# define BOARD_LED_ON                   gpio_clear
+# define BOARD_LED_OFF                  gpio_set
 
 #else
 # error Undefined Target Hardware


### PR DESCRIPTION
Added support for the ModalAI FMU v5m, an f7 based device.
BOARD_TYPE is set to USB PID (41775) per feedback from David Sidrane (via Slack chat)
USB VID= 0x0483, PID: 0xA32F provided through STMicroelectronics
The FMUv5m Blue LED (1) isn't on Port B so set the activity to the red LED (1).