### PR TITLE
Add support for ModalAI FC1 target

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,7 +29,8 @@ pipeline {
                      "px4fmuv4pro_bl",
                      "px4fmuv5_bl",
                      "px4io_bl",
-                     "smartap_pro_bl"
+                     "smartap_pro_bl",
+                     "modalai_fc1_bl"
             ],
             image: docker_images.nuttx,
             archive: true

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ TARGETS	= \
 	px4iov3_bl \
 	tapv1_bl \
 	smartap_pro_bl \
-	modalai_fc1_bl
+	modalai_fc_v1_bl
 
 all:	$(TARGETS) sizes
 

--- a/Makefile
+++ b/Makefile
@@ -145,8 +145,8 @@ avx_v1_bl:$(MAKEFILE_LIST) $(LIBOPENCM3)
 smartap_pro_bl:$(MAKEFILE_LIST) $(LIBOPENCM3)
 	${MAKE} ${MKFLAGS} -f  Makefile.f7 TARGET_HW=SMARTAP_PRO LINKER_FILE=stm32f7.ld TARGET_FILE_NAME=$@
 
-modalai_fc1_bl:$(MAKEFILE_LIST) $(LIBOPENCM3)
-	${MAKE} ${MKFLAGS} -f  Makefile.f7 TARGET_HW=MODALAI_FC1 LINKER_FILE=stm32f7.ld TARGET_FILE_NAME=$@
+modalai_fc_v1_bl:$(MAKEFILE_LIST) $(LIBOPENCM3)
+	${MAKE} ${MKFLAGS} -f  Makefile.f7 TARGET_HW=MODALAI_FC_V1 LINKER_FILE=stm32f7.ld TARGET_FILE_NAME=$@
 
 # Default bootloader delay is *very* short, just long enough to catch
 # the board for recovery but not so long as to make restarting after a

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,8 @@ TARGETS	= \
 	px4io_bl \
 	px4iov3_bl \
 	tapv1_bl \
-	smartap_pro_bl
+	smartap_pro_bl \
+	modalai_fc1_bl
 
 all:	$(TARGETS) sizes
 
@@ -143,6 +144,9 @@ avx_v1_bl:$(MAKEFILE_LIST) $(LIBOPENCM3)
 
 smartap_pro_bl:$(MAKEFILE_LIST) $(LIBOPENCM3)
 	${MAKE} ${MKFLAGS} -f  Makefile.f7 TARGET_HW=SMARTAP_PRO LINKER_FILE=stm32f7.ld TARGET_FILE_NAME=$@
+
+modalai_fc1_bl:$(MAKEFILE_LIST) $(LIBOPENCM3)
+	${MAKE} ${MKFLAGS} -f  Makefile.f7 TARGET_HW=MODALAI_FC1 LINKER_FILE=stm32f7.ld TARGET_FILE_NAME=$@
 
 # Default bootloader delay is *very* short, just long enough to catch
 # the board for recovery but not so long as to make restarting after a

--- a/board_types.txt
+++ b/board_types.txt
@@ -26,6 +26,7 @@ TARGET_HW_CUBE_F4                       9
 TARGET_HW_AV_V1                        29
 TARGET_HW_KAKUTEF7                    123
 TARGET_HW_SMARTAP_PRO                  32
+TARGET_HW_MODALAI_FC1               41775
 
 # values from external vendors
 EXT_HW_RADIOLINK_MINI_PIX               3

--- a/board_types.txt
+++ b/board_types.txt
@@ -26,7 +26,7 @@ TARGET_HW_CUBE_F4                       9
 TARGET_HW_AV_V1                        29
 TARGET_HW_KAKUTEF7                    123
 TARGET_HW_SMARTAP_PRO                  32
-TARGET_HW_MODALAI_FC1               41775
+TARGET_HW_MODALAI_FC_V1             41775
 
 # values from external vendors
 EXT_HW_RADIOLINK_MINI_PIX               3

--- a/hw_config.h
+++ b/hw_config.h
@@ -1048,16 +1048,16 @@
 # define BOARD_LED_OFF                  gpio_clear
 
 /****************************************************************************
- * TARGET_HW_MODALAI_FC1
+ * TARGET_HW_MODALAI_FC_V1
  ****************************************************************************/
 
-#elif  defined(TARGET_HW_MODALAI_FC1)
+#elif  defined(TARGET_HW_MODALAI_FC_V1)
 
 # define APP_LOAD_ADDRESS               0x08008000
 # define BOOTLOADER_DELAY               5000
 # define INTERFACE_USB                  1
 # define INTERFACE_USART                1
-# define USBDEVICESTRING                "PX4 BL ModalAI FC1"
+# define USBDEVICESTRING                "PX4 BL ModalAI FCv1"
 # define USBMFGSTRING                   "ModalAI"
 # define USBPRODUCTID                   0xa32f
 # define USBVENDORID                    0x0483

--- a/hw_config.h
+++ b/hw_config.h
@@ -1047,6 +1047,47 @@
 # define BOARD_LED_ON                   gpio_set
 # define BOARD_LED_OFF                  gpio_clear
 
+/****************************************************************************
+ * TARGET_HW_MODALAI_FC1
+ ****************************************************************************/
+
+#elif  defined(TARGET_HW_MODALAI_FC1)
+
+# define APP_LOAD_ADDRESS               0x08008000
+# define BOOTLOADER_DELAY               5000
+# define INTERFACE_USB                  1
+# define INTERFACE_USART                1
+# define USBDEVICESTRING                "PX4 BL ModalAI FC1"
+# define USBMFGSTRING                   "ModalAI"
+# define USBPRODUCTID                   0xa32f
+# define USBVENDORID                    0x0483
+# define BOOT_DELAY_ADDRESS             0x000001a0
+
+# define BOARD_TYPE                     41775
+# define _FLASH_KBYTES                  (*(uint16_t *)0x1ff0f442)
+# define BOARD_FLASH_SECTORS            ((_FLASH_KBYTES == 0x400) ? 7 : 11)
+# define BOARD_FLASH_SIZE               (_FLASH_KBYTES * 1024)
+
+# define OSC_FREQ                       16
+
+# define BOARD_PIN_LED_ACTIVITY         GPIO0 // RED
+# define BOARD_PIN_LED_BOOTLOADER       GPIO1 // GREEN
+# define BOARD_PORT_LEDS                GPIOB
+# define BOARD_CLOCK_LEDS               RCC_AHB1ENR_GPIOBEN
+# define BOARD_LED_ON                   gpio_clear
+# define BOARD_LED_OFF                  gpio_set
+
+# define BOARD_USART                    USART3
+# define BOARD_USART_CLOCK_REGISTER     RCC_APB1ENR
+# define BOARD_USART_CLOCK_BIT          RCC_APB1ENR_USART3EN
+
+# define BOARD_PORT_USART               GPIOD
+# define BOARD_PORT_USART_AF            GPIO_AF7
+# define BOARD_PIN_TX                   GPIO8
+# define BOARD_PIN_RX                   GPIO9
+# define BOARD_USART_PIN_CLOCK_REGISTER RCC_AHB1ENR
+# define BOARD_USART_PIN_CLOCK_BIT      RCC_AHB1ENR_GPIODEN
+# define SERIAL_BREAK_DETECT_DISABLED   1
 
 #else
 # error Undefined Target Hardware


### PR DESCRIPTION
Board ID: 41775 (0xA32F)
VID: 0x0483 (STMicroelectronics, approved by vendor)
PID: 0xa32f
USBDeviceString: "PX4 BL ModalAI FCv1"

Supports serial DFU over USART3 (debug header on hardware)