### PR TITLE
bl Remove compile time dependency on libcm3

### DIFF
--- a/bl.h
+++ b/bl.h
@@ -110,6 +110,11 @@ extern void flash_func_write_word(uint32_t address, uint32_t word);
 extern uint32_t flash_func_read_word(uint32_t address);
 extern uint32_t flash_func_read_otp(uint32_t address);
 extern uint32_t flash_func_read_sn(uint32_t address);
+extern void arch_flash_lock(void);
+extern void arch_flash_unlock(void);
+extern void arch_setvtor(uint32_t address);
+void arch_systic_init(void);
+void arch_systic_deinit(void);
 
 extern uint32_t get_mcu_id(void);
 int get_mcu_desc(int max, uint8_t *revstr);

--- a/cdcacm.h
+++ b/cdcacm.h
@@ -40,7 +40,7 @@
 #pragma once
 
 
-extern void usb_cinit(void);
+extern void usb_cinit(void *pconfig);
 extern void usb_cfini(void);
 extern int usb_cin(void);
 extern void usb_cout(uint8_t *buf, unsigned len);

--- a/main_f3.c
+++ b/main_f3.c
@@ -11,6 +11,7 @@
 #include <libopencm3/stm32/flash.h>
 #include <libopencm3/stm32/usart.h>
 #include <libopencm3/stm32/pwr.h>
+#include <libopencm3/cm3/scb.h>
 #include <libopencm3/cm3/systick.h>
 
 #include "bl.h"
@@ -153,6 +154,22 @@ clock_init(void)
 	rcc_clock_setup_hsi(&_rcc_hsi_8mhz);
 }
 
+inline void arch_systic_init(void)
+{
+	/* (re)start the timer system */
+	systick_set_clocksource(STK_CSR_CLKSOURCE_AHB);
+	systick_set_reload(board_info.systick_mhz * 1000);  /* 1ms tick, magic number */
+	systick_interrupt_enable();
+	systick_counter_enable();
+}
+
+inline void arch_systic_deinit(void)
+{
+	/* kill the systick interrupt */
+	systick_interrupt_disable();
+	systick_counter_disable();
+}
+
 /**
   * @brief  Resets the RCC clock configuration to the default reset state.
   * @note   The default reset state of the clock configuration is given below:
@@ -185,6 +202,21 @@ clock_deinit(void)
 
 	/* Reset the CIR register */
 	RCC_CIR = 0x000000;
+}
+
+inline void arch_flash_lock(void)
+{
+	flash_lock();
+}
+
+inline void arch_flash_unlock(void)
+{
+	flash_unlock();
+}
+
+inline void arch_setvtor(uint32_t address)
+{
+	SCB_VTOR = address;
 }
 
 /*---------------------------------------------------------------------------*/

--- a/main_f4.c
+++ b/main_f4.c
@@ -12,7 +12,9 @@
 #include <libopencm3/stm32/usart.h>
 #include <libopencm3/cm3/systick.h>
 #include <libopencm3/stm32/pwr.h>
-# include <libopencm3/stm32/timer.h>
+#include <libopencm3/stm32/timer.h>
+#include <libopencm3/cm3/scb.h>
+#include <libopencm3/cm3/systick.h>
 
 #include "bl.h"
 #include "uart.h"
@@ -485,6 +487,22 @@ clock_init(void)
 	rcc_clock_setup_hse_3v3(&clock_setup);
 }
 
+inline void arch_systic_init(void)
+{
+	/* (re)start the timer system */
+	systick_set_clocksource(STK_CSR_CLKSOURCE_AHB);
+	systick_set_reload(board_info.systick_mhz * 1000);  /* 1ms tick, magic number */
+	systick_interrupt_enable();
+	systick_counter_enable();
+}
+
+inline void arch_systic_deinit(void)
+{
+	/* kill the systick interrupt */
+	systick_interrupt_disable();
+	systick_counter_disable();
+}
+
 /**
   * @brief  Resets the RCC clock configuration to the default reset state.
   * @note   The default reset state of the clock configuration is given below:
@@ -520,6 +538,21 @@ clock_deinit(void)
 
 	/* Reset the CIR register */
 	RCC_CIR = 0x000000;
+}
+
+inline void arch_flash_lock(void)
+{
+	flash_lock();
+}
+
+inline void arch_flash_unlock(void)
+{
+	flash_unlock();
+}
+
+inline void arch_setvtor(uint32_t address)
+{
+	SCB_VTOR = address;
 }
 
 uint32_t

--- a/stm32/cdcacm.c
+++ b/stm32/cdcacm.c
@@ -301,7 +301,7 @@ otg_fs_isr(void)
 }
 
 void
-usb_cinit(void)
+usb_cinit(void *pconfig)
 {
 #if defined(STM32F4)
 


### PR DESCRIPTION
@dagar - this is a step (albeit it limited by the PX4IO) in being able to compile the bootloader in a non libcm3 build.

If you are OK with the changes. I think we want to have it tested on F1, F4, F7 and K66 before merging.

