### PR TITLE
Added ArduPilot IDs

### DIFF
--- a/board_types.txt
+++ b/board_types.txt
@@ -87,3 +87,4 @@ AP_HW_CUAV_NORA                      1009
 AP_HW_CUAV_X7_PRO                    1010
 AP_HW_SUCCEXF4                       1011
 AP_HW_MRO_CONTROL_ZERO_PR            1012
+AP_HW_LIGHTSPARKMINI                 1013

--- a/board_types.txt
+++ b/board_types.txt
@@ -86,5 +86,7 @@ AP_HW_FRSKY_R9                       1008
 AP_HW_CUAV_NORA                      1009
 AP_HW_CUAV_X7_PRO                    1010
 AP_HW_SUCCEXF4                       1011
-AP_HW_MRO_CONTROL_ZERO_PR            1012
-AP_HW_LIGHTSPARKMINI                 1013
+AP_HW_LIGHTSPARKMINI                 1012
+AP_HW_MATEKH743                      1013
+AP_HW_MRO_CONTROL_ZERO_PR            1014
+

--- a/board_types.txt
+++ b/board_types.txt
@@ -40,6 +40,9 @@ EXT_HW_RADIOLINK_MINI_PIX               3
 # use by the ArduPilot bootloader. Do not allocate IDs in this range
 # except via changes to the ArduPilot code
 
+# Do not allocate IDs in the range 1000 to 1999 except via a PR
+# against https://github.com/ArduPilot/Bootloader
+
 # values starting with AP_ are implemented in the ArduPilot bootloader
 # https://github.com/ArduPilot/ardupilot/tree/master/Tools/AP_Bootloader
 # the values come from the APJ_BOARD_ID in the hwdef files here:


### PR DESCRIPTION
Fixes ID of -AP_HW_MRO_CONTROL_ZERO_PR to remove conflict and adds two new boards