### PR TITLE
Reserve Holybro PIX32-V5

### DIFF
--- a/board_types.txt
+++ b/board_types.txt
@@ -28,6 +28,7 @@ TARGET_HW_AV_V1                        29
 TARGET_HW_KAKUTEF7                    123
 TARGET_HW_SMARTAP_PRO                  32
 TARGET_HW_MODALAI_FC_V1             41775
+TARGET_HW_HB_PIX32_V5                  78
 
 Reserved  PX4 [BL] FMU v5X.x           51
 Reserved "PX4 [BL] FMU v6.x"           52

--- a/board_types.txt
+++ b/board_types.txt
@@ -28,7 +28,7 @@ TARGET_HW_AV_V1                        29
 TARGET_HW_KAKUTEF7                    123
 TARGET_HW_SMARTAP_PRO                  32
 TARGET_HW_MODALAI_FC_V1             41775
-TARGET_HW_HB_PIX32_V5                  78
+TARGET_HW_HOLYBRO_PIX32_V5                  78
 
 Reserved  PX4 [BL] FMU v5X.x           51
 Reserved "PX4 [BL] FMU v6.x"           52
@@ -93,4 +93,3 @@ AP_HW_SUCCEXF4                       1011
 AP_HW_LIGHTSPARKMINI                 1012
 AP_HW_MATEKH743                      1013
 AP_HW_MRO_CONTROL_ZERO_PR            1014
-


### PR DESCRIPTION
USB Vendor ID: 0x3162
USB Product ID: 0x004E
USB Device String: PIX32-V5
USB MFG String: Holybro