### PR TITLE
Document assigned ID

### DIFF
--- a/board_types.txt
+++ b/board_types.txt
@@ -28,7 +28,12 @@ TARGET_HW_AV_V1                        29
 TARGET_HW_KAKUTEF7                    123
 TARGET_HW_SMARTAP_PRO                  32
 TARGET_HW_MODALAI_FC_V1             41775
-TARGET_HW_HOLYBRO_PIX32_V5                  78
+TARGET_HW_HOLYBRO_PIX32_V5             78
+TARGET_HW_FMUK66_V3                    28
+TARGET_HW_AV_X_V1                      29
+TARGET_HW_FMUK66_E                     30
+TARGET_HW_FMURT1062-V1                 31
+
 
 Reserved  PX4 [BL] FMU v5X.x           51
 Reserved "PX4 [BL] FMU v6.x"           52


### PR DESCRIPTION
Document the existing ID's of
TARGET_HW_FMUK66_V3 and TARGET_HW_AV_X_V1

Assign:
TARGET_HW_FMUK66_E
TARGET_HW_FMURT1062-V1
