### PR TITLE
PX4 Bootloader:Track QGC change in sequencing

### DIFF
--- a/bl.c
+++ b/bl.c
@@ -588,7 +588,7 @@ bootloader(unsigned timeout)
 				goto cmd_bad;
 			}
 
-			bl_state = STATE_PROTO_GET_SYNC;
+			SET_BL_STATE(STATE_PROTO_GET_SYNC);
 			break;
 
 		// get device info


### PR DESCRIPTION
   It appear that QGC is now resyncing between operation.
   This was causing the bl_state to be reset to STATE_PROTO_GET_SYNC
   and loosing the state of (STATE_PROTO_GET_SYNC|STATE_PROTO_GET_DEVICE)