### PR TITLE
px4io_bl:Fix breakage from b2acae83.

### DIFF
--- a/bl.c
+++ b/bl.c
@@ -141,10 +141,12 @@
 #define STATE_ALLOWS_ERASE        (STATE_PROTO_GET_SYNC)
 #define STATE_ALLOWS_REBOOT       (STATE_PROTO_GET_SYNC)
 #  define SET_BL_STATE(s)
+#  define SET_BL_FIRST_STATE(s)   bl_state |= (s)
 #else
 #define STATE_ALLOWS_ERASE        (STATE_PROTO_GET_SYNC|STATE_PROTO_GET_DEVICE)
 #define STATE_ALLOWS_REBOOT       (STATE_ALLOWS_ERASE|STATE_PROTO_PROG_MULTI|STATE_PROTO_GET_CRC)
-#  define SET_BL_STATE(s) bl_state |= (s)
+#  define SET_BL_STATE(s)         bl_state |= (s)
+#  define SET_BL_FIRST_STATE(s)   bl_state |= (s)
 #endif
 
 static uint8_t bl_type;
@@ -588,7 +590,7 @@ bootloader(unsigned timeout)
 				goto cmd_bad;
 			}
 
-			SET_BL_STATE(STATE_PROTO_GET_SYNC);
+			SET_BL_FIRST_STATE(STATE_PROTO_GET_SYNC);
 			break;
 
 		// get device info


### PR DESCRIPTION
   The PX4IO which is limitted on flash, did not intializing the
   PROTO_GET_SYNC state as SET_BL_STATE was a no-op.
   Prior to b2acae83 the value was assinged to the state with an
   assigment. b2acae83 replaced the = with the macro.  The fix is
   declearing SET_BL_FIRST_STATE as the |= and using it in
   PROTO_GET_SYNC.