### PR TITLE
f4: update deprecated setup_hse_3v3 to setup_pll

### DIFF
--- a/main_f4.c
+++ b/main_f4.c
@@ -484,7 +484,7 @@ board_deinit(void)
 static inline void
 clock_init(void)
 {
-	rcc_clock_setup_hse_3v3(&clock_setup);
+	rcc_clock_setup_pll(&clock_setup);
 }
 
 inline void arch_systic_init(void)


### PR DESCRIPTION
From libopencm3's STM32F4 documentation:

```
void rcc_clock_setup_hse_3v3(const struct rcc_clock_scale *clock) 

Setup clocks with the HSE.

Deprecated:
    replaced by rcc_clock_setup_pll as a drop in replacement. 

See also
    rcc_clock_setup_pll which supports HSI as well as HSE, using the same clock structures.
```